### PR TITLE
New functions to get summary from jira id under your cursor.

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -443,6 +443,25 @@ jql."
     (jiralib-do-jql-search jql)))
 
 ;;;###autoload
+(defun org-jira-get-summary ()
+  "Get issue summary from point and place next to issue id from jira"
+  (interactive)
+  (let ((jira_id (thing-at-point 'symbol)))
+    (forward-symbol 1)
+    (insert (format " - %s" 
+      (cdr (assoc 'summary (car (org-jira-get-issue-by-id jira_id))))))))
+
+;;;###autoload
+(defun org-jira-get-summary-url ()
+  "Get issue summary from point and place next to issue id from jira, and make issue id a link"
+  (interactive)
+  (let ((jira_id (thing-at-point 'symbol)))
+    (sp-kill-symbol 1)
+    (insert (format "[[%s][%s]] - %s"
+      (concatenate 'string jiralib-url "browse/" jira_id) jira_id  
+      (cdr (assoc 'summary (car (org-jira-get-issue-by-id jira_id))))))))
+
+;;;###autoload
 (defun org-jira-get-issues-headonly (issues)
   "Get list of ISSUES, head only.
 


### PR DESCRIPTION
As discussed here, https://github.com/baohaojun/org-jira/issues/51

The first function just inserts the summary
The second converts the jira id into a link and places the summary next to it.