### PR TITLE
Get issues by fixversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Some of the important keybindings:
 (define-key org-jira-map (kbd "C-c cu") 'org-jira-update-comment)
 (define-key org-jira-map (kbd "C-c wu") 'org-jira-update-worklogs-from-org-clocks)
 (define-key org-jira-map (kbd "C-c tj") 'org-jira-todo-to-jira)
+(define-key org-jira-map (kbd "C-c if") 'org-jira-get-issues-by-fixversion)
 ```
 
 ## About

--- a/org-jira.el
+++ b/org-jira.el
@@ -244,6 +244,9 @@ instance."
 (defvar org-jira-issue-id-history '()
   "Prompt history for issue id.")
 
+(defvar org-jira-fixversion-id-history '()
+  "Prompt history for fixversion id.")
+
 (defmacro ensure-on-issue (&rest body)
   "Make sure we are on an issue heading, before executing BODY."
   (declare (debug (body)))
@@ -632,6 +635,12 @@ jql."
   (let ((jql (format "id = %s" id)))
     (jiralib-do-jql-search jql)))
 
+(defun org-jira-get-issue-by-fixversion (fixversion-id)
+  "Get an issue by its FIXVERSION-ID."
+  (push fixversion-id org-jira-fixversion-id-history)
+  (let ((jql (format "fixVersion = \"%s\""  fixversion-id)))
+    (jiralib-do-jql-search jql)))
+
 ;;;###autoload
 (defun org-jira-get-summary ()
   "Get issue summary from point and place next to issue id from jira"
@@ -681,6 +690,13 @@ With a prefix argument, allow you to customize the jql.  See
   "Get a JIRA issue, allowing you to enter the issue-id first."
   (interactive (list (read-string "Issue ID: " "" 'org-jira-issue-id-history)))
   (org-jira-get-issues (org-jira-get-issue-by-id id)))
+
+;;;###autoload
+(defun org-jira-get-issues-by-fixversion (fixversion)
+  "Get list of issues by FIXVERSION."
+  (interactive (list (read-string "Fixversion ID: " ""
+                                  'org-jira-fixversion-id-history)))
+  (org-jira-get-issues (org-jira-get-issue-by-fixversion fixversion)))
 
 ;;;###autoload
 (defun org-jira-get-issue-project (issue)


### PR DESCRIPTION
I've added the ability to get issues based on the fixVersion jql parameter.  The change is relatively minor (doesn't change any existing code).  

I've added a new keybind to the user-facing function `org-jira-get-issues-by-fixversion' on both the map defined in org-jira.el as well as updated the README with the new bind.  I'm totally happy to change the keybind if you think it is necessary -- I'm an Evil user so I've got my own bindings for everything anyways.

The only issue with this that I encountered was that for fixVersions with 90+ issues, I get an error about `apply: Creating pipe: Too many open files` which appears to be a Windows-specific issue.

I imagine that if I tried to query a similar amount of issues via one of the existing functions, I'd probably run into the same error.