### PR TITLE
Fix "Components" default type

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -1678,7 +1678,7 @@ otherwise it should return:
      (let ((update-fields
             (list (cons
                    'components
-                   (org-jira-build-components-list project-components))
+                   (or (org-jira-build-components-list project-components) []))
                   (cons 'priority (org-jira-get-id-name-alist org-issue-priority
                                                               (jiralib-get-priorities)))
                   (cons 'description org-issue-description)


### PR DESCRIPTION
When updating a JIRA issue, if `:components:` is not listed, a `null` is sent as part of the REST API payload. However, according to https://org.atlassian.net/rest/api/2/issue/PRJ-123/editmeta the type is an array, not a string. The request currently fails with a 400 status code and the following response body:

    {"errorMessages":[],"errors":{"components":"data was not an array"}}

To support this, this PR provides the valid default value. This also supports the case to remove all components from a JIRA issue.