### PR TITLE
Support for jira agile api and loading issues from Jira boards

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -345,6 +345,7 @@ request.el, so if at all possible, it should be avoided."
                      (format "/rest/api/2/issue/%s/comment/%s" (first params) (second params))
                      :data (json-encode `((body . ,(third params))))
                      :type "PUT"))
+      ('getBoards (jiralib--agile-call-it "/rest/agile/1.0/board" 'values))
       ('getComments (org-jira-find-value
                      (jiralib--rest-call-it
                       (format "/rest/api/2/issue/%s/comment" (first params)))
@@ -357,6 +358,9 @@ request.el, so if at all possible, it should be avoided."
                        (format "/rest/api/2/project/%s/components" (first params))))
       ('getIssue (jiralib--rest-call-it
                   (format "/rest/api/2/issue/%s" (first params))))
+      ('getIssuesFromBoard  (jiralib--agile-call-it
+			     (format "rest/agile/1.0/board/%d/issue" (first params))
+			     'issues))
       ('getIssuesFromJqlSearch  (append (cdr ( assoc 'issues (jiralib--rest-call-it
                                                               "/rest/api/2/search"
                                                               :type "POST"
@@ -1039,6 +1043,108 @@ Auxiliary Notes:
 	(funcall rewrap-worklog-records-fn worklogs))))))
 
 
+(defun jiralib-get-boards ()
+  "Return list of jira boards"
+  (jiralib-call "getBoards" nil))
+
+(defun jiralib-get-board-issues (board-id &optional callback)
+  "Return list of jira issues in the specified jira board"
+  (jiralib-call "getIssuesFromBoard" callback board-id))
+
+(defun jiralib--agile-add-paging-params (api max-results start-at)
+  "Add paging parameters to jira agile url"
+  (format "%s?maxResults=%d&startAt=%d" api  max-results start-at))
+
+
+(defun jiralib--agile-call-it (api values-key)
+  "Invoke Jira agile method api and retrieve the results using
+paging.
+
+If JIRALIB-COMPLETE-CALLBACK is non-nil, then the call will be
+performed asynchronously and JIRALIB-COMPLETE-CALLBACK will be
+called when all data are retrieved.
+
+If JIRALIB-COMPLETE-CALLBACK is nil, then the call will be
+performed syncronously and this function will return the
+retrieved data.
+
+API - url that must start with /rest/agile/1.0.
+
+VALUES-KEY - key of the actual reply data in the reply assoc list."
+  (if jiralib-complete-callback
+      (jiralib--agile-call-async api values-key)
+    (jiralib--agile-call-sync api values-key)))
+
+
+(defun jiralib--agile-call-sync (api values-key)
+  "Syncroniously invoke Jira agile method api retrieve all the
+results using paging and return results.
+
+VALUES-KEY - key of the actual reply data in the reply assoc list."
+  (setq jiralib-complete-callback nil)
+  (let ((not-last t)
+	(start-at 0)
+	;; 50 is server side maximum
+	(max-results 10)
+	(values ()))
+    (while not-last
+      (let* ((reply-alist (jiralib--rest-call-it
+			   (jiralib--agile-add-paging-params api  max-results start-at)))
+	     (values-array (cdr (assoc values-key reply-alist)))
+	     (num-entries (length values-array))
+	     (total (cdr (assq 'total reply-alist))))
+	(setf values (append values (append values-array nil)))
+	(setf start-at (+ start-at num-entries))
+	(setf not-last (and (>  num-entries 0)
+			    (or (not total) ;; not always returned
+				(> total start-at))))))
+    values))
+
+(defun jiralib--agile-call-async  (api values-key)
+  "Asyncroniously invoke Jira agile method api,
+retrieve all the results using paging and call
+JIRALIB-COMPLETE_CALLBACK when all the data are retrieved.
+
+VALUES-KEY - key of the actual reply data in the reply assoc list."
+  (lexical-let
+      ((start-at 0)
+       ;; 50 is server side maximum
+       (max-results 50)
+       (values-list ())
+       (vk values-key)
+       (url api)
+       ;; save the call back to be called later after the last page
+       (complete-callback jiralib-complete-callback))
+    ;; setup new callback to be called after each page
+    (setf jiralib-complete-callback
+	  (cl-function
+	   (lambda  (&rest data &allow-other-keys)
+	     (condition-case err
+		 (let* ((reply-alist (cl-getf data :data))
+			(values-array (cdr (assoc vk reply-alist)))
+			(num-entries (length values-array))
+			(total (cdr (assq 'total reply-alist))))
+		   (setf values-list (append values-list (append values-array nil)))
+		   (setf start-at (+ start-at num-entries))
+		   (message "jiralib agile retrieve: got %d values%s%s"
+			    start-at
+			    (if total " of " "")
+			    (if total (int-to-string total) ""))
+		   (if (and (>  num-entries 0)
+  			    (or (not total) ; not always returned
+				(> total start-at)))
+		       (jiralib--rest-call-it
+			(jiralib--agile-add-paging-params url  max-results start-at))
+		     (progn
+		       ;; last page: call originall callback
+		       (message "jiralib agile retrieve: calling callback")
+		       (setf jiralib-complete-callback complete-callback)
+		       (funcall jiralib-complete-callback
+			     :data  (list (cons vk  values-list)))
+		       (message "jiralib agile retrieve: all done"))))
+               ('error (message (format "jiralib agile retrieve: caught error: %s" err)))))))
+    (jiralib--rest-call-it
+     (jiralib--agile-add-paging-params api  max-results start-at))))
 
 (provide 'jiralib)
 ;;; jiralib.el ends here

--- a/org-jira.el
+++ b/org-jira.el
@@ -351,6 +351,8 @@ instance."
 (defvar org-jira-entry-mode-map
   (let ((org-jira-map (make-sparse-keymap)))
     (define-key org-jira-map (kbd "C-c pg") 'org-jira-get-projects)
+    (define-key org-jira-map (kbd "C-c bg") 'org-jira-get-boards)
+    (define-key org-jira-map (kbd "C-c iv") 'org-jira-get-issues-by-board)
     (define-key org-jira-map (kbd "C-c ib") 'org-jira-browse-issue)
     (define-key org-jira-map (kbd "C-c ig") 'org-jira-get-issues)
     (define-key org-jira-map (kbd "C-c ih") 'org-jira-get-issues-headonly)
@@ -1255,6 +1257,7 @@ purpose of wiping an old subtree."
    (org-jira-get-issues-headonly (jiralib-do-jql-search (format "parent = %s" (org-jira-parse-issue-id))))))
 
 (defvar org-jira-project-read-history nil)
+(defvar org-jira-boards-read-history nil)
 (defvar org-jira-priority-read-history nil)
 (defvar org-jira-type-read-history nil)
 
@@ -1268,6 +1271,17 @@ purpose of wiping an old subtree."
    nil
    'org-jira-project-read-history
    (car org-jira-project-read-history)))
+
+(defun org-jira-read-board ()
+  "Read board name. Returns cons pair (name . integer-id)"
+  (let* ((boards-alist
+	  (jiralib-make-assoc-list (jiralib-get-boards) 'name 'id))
+	 (board-name
+	  (completing-read "Boards: "  boards-alist
+			   nil  t  nil
+			   'org-jira-boards-read-history
+			   (car org-jira-boards-read-history))))
+    (assoc board-name boards-alist)))
 
 (defun org-jira-read-priority ()
   "Read priority name."
@@ -1862,6 +1876,67 @@ See `org-jira-get-issues-from-filter'."
 (defun org-jira-open (path)
   "Open a Jira Link from PATH."
   (org-jira-get-issue path))
+
+;;;###autoload
+(defun org-jira-get-issues-by-board ()
+  "Get list of ISSUES from agile board."
+  (interactive)
+  (let* ((board (org-jira-read-board))
+	 (board-id (cdr board)))
+    (jiralib-get-board-issues board-id org-jira-get-issue-list-callback)))
+
+;;;###autoload
+(defun org-jira-get-issues-by-board-headonly ()
+  "Get list of ISSUES from agile board, head only."
+  (interactive)
+  (let* ((board (org-jira-read-board))
+	 (board-id (cdr board)))
+    (org-jira-get-issues-headonly (jiralib-get-board-issues board-id))))
+
+;;;###autoload
+(defun org-jira-get-boards ()
+  "Get list of projects."
+  (interactive)
+  (lexical-let* ((boards-file (expand-file-name "boards-list.org" org-jira-working-dir))
+		 (existing-buffer (find-buffer-visiting boards-file))
+		 (boards (jiralib-get-boards)))
+    (save-excursion
+      (if existing-buffer
+	  (pop-to-buffer (set-buffer existing-buffer))
+        (find-file boards-file))
+      (org-jira-mode t)
+      (org-save-outline-visibility t
+	(outline-show-all)
+	(save-restriction
+	  (mapc (lambda (board)
+		  (widen)
+		  (goto-char (point-min))
+		  (let* ((board-id (org-jira-find-value board 'id))
+			 (board-name (org-jira-find-value board 'name))
+			 (board-url
+			  (format "%s/secure/RapidBoard.jspa?rapidView=%d"
+				  (replace-regexp-in-string "/*$" "" jiralib-url) board-id))
+			 (board-headline
+			  (format "Board: [[%s][%s]]" board-url board-name))
+			 (headline-pos (org-find-exact-headline-in-buffer
+					board-headline (current-buffer) t)))
+		    (if (and headline-pos (>= headline-pos (point-min))
+                             (<= headline-pos (point-max)))
+			(progn
+                          (goto-char headline-pos)
+                          (org-narrow-to-subtree)
+                          (end-of-line))
+                      (goto-char (point-max))
+                      (unless (looking-at "^")
+			(insert "\n"))
+                      (insert "* ")
+                      (org-jira-insert board-headline)
+                      (org-narrow-to-subtree))
+                    (org-jira-entry-put (point) "name" board-name)
+                    (org-jira-entry-put (point) "type" (cdr (assoc 'type board)))
+		    (org-jira-entry-put (point) "url" board-url)
+                    (org-jira-entry-put (point) "ID" (number-to-string board-id))))
+		boards))))))
 
 (provide 'org-jira)
 ;;; org-jira.el ends here


### PR DESCRIPTION
Hi, please could you merge this?

The pull request adds to jiralib support for fetching data using jira agile api (/rest/agile/1.0/) and new commands to org-jira: 
* org-jira-get-boards - get list of boards
* org-jira-get-issues-by-board and org-jira-get-issues-by-board-headonly - let user select board and fetch issues

This is very much work in progress: currently the issues are still fetched in the per project files, I plan to add support for per board .org files.

Thanks!