### PR TITLE
Fix retrieving associated org keyword.

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -1991,7 +1991,7 @@ See `org-jira-get-issues-from-filter'."
   (if org-jira-use-status-as-todo
       (upcase (replace-regexp-in-string " " "-" status))
     (let ((known-keyword (assoc status org-jira-keywords-to-jira-status-alist)))
-      (cond (known-keyword known-keyword)
+      (cond (known-keyword (cdr known-keyword))
             ((member status org-jira-done-states) "DONE")
             ("TODO")))))
 


### PR DESCRIPTION
This is a follow up from: https://github.com/ahungry/org-jira/pull/105

Didn't realize this change was not on my fork, the original code from the PR above is returning an invalid value: It returns the pair in the alist, instead the value which is what we want.