### PR TITLE
Cleanup whitespace for easier collaboration and setup .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{el}]
+indent_style = space

--- a/jiralib.el
+++ b/jiralib.el
@@ -351,16 +351,16 @@ request.el, so if at all possible, it should be avoided."
                       (format "/rest/api/2/issue/%s/comment" (first params)))
                      'comments))
       ('getAttachmentsFromIssue (org-jira-find-value
-                     (jiralib--rest-call-it
-                      (format "/rest/api/2/issue/%s?fields=attachment" (first params)))
-                     'comments))
+                                 (jiralib--rest-call-it
+                                  (format "/rest/api/2/issue/%s?fields=attachment" (first params)))
+                                 'comments))
       ('getComponents (jiralib--rest-call-it
                        (format "/rest/api/2/project/%s/components" (first params))))
       ('getIssue (jiralib--rest-call-it
                   (format "/rest/api/2/issue/%s" (first params))))
       ('getIssuesFromBoard  (jiralib--agile-call-it
-			     (format "rest/agile/1.0/board/%d/issue" (first params))
-			     'issues))
+                             (format "rest/agile/1.0/board/%d/issue" (first params))
+                             'issues))
       ('getIssuesFromJqlSearch  (append (cdr ( assoc 'issues (jiralib--rest-call-it
                                                               "/rest/api/2/search"
                                                               :type "POST"
@@ -421,7 +421,7 @@ passing ARGS to REQUEST."
                   :headers `(,jiralib-token ("Content-Type" . "application/json"))
                   :parser 'json-read
                   :complete jiralib-complete-callback
-                  args))
+             args))
           nil))
 
 (defun jiralib--call-it (method &rest params)
@@ -1010,37 +1010,37 @@ Auxiliary Notes:
     ;; let-body
     (progn
       (setq unwrap-worklog-records-fn
-	    (if (and
-		 (boundp 'unwrap-worklog-records-fn)
-		 (functionp unwrap-worklog-records-fn))
-		unwrap-worklog-records-fn
-	      (lambda (x) (coerce x 'list))))
+            (if (and
+                 (boundp 'unwrap-worklog-records-fn)
+                 (functionp unwrap-worklog-records-fn))
+                unwrap-worklog-records-fn
+              (lambda (x) (coerce x 'list))))
       (setq rewrap-worklog-records-fn
-	    (if (and
-		 (boundp 'rewrap-worklog-records-fn)
-		 (functionp rewrap-worklog-records-fn))
-		rewrap-worklog-records-fn
-	      (lambda (x) (remove 'nil (coerce x 'vector)))))
+            (if (and
+                 (boundp 'rewrap-worklog-records-fn)
+                 (functionp rewrap-worklog-records-fn))
+                rewrap-worklog-records-fn
+              (lambda (x) (remove 'nil (coerce x 'vector)))))
       (setq predicate-fn-lst
-	    (if (and (boundp 'predicate-fn-lst)
-		     (not (null predicate-fn-lst))
-		     (listp predicate-fn-lst))
-		predicate-fn-lst
-	      (mapcar 'caddr
-		      (remove 'nil
-			      (mapcar (lambda (x) (unless (null (car x)) x))
-				      jiralib-worklog-import--filters-alist)))))
+            (if (and (boundp 'predicate-fn-lst)
+                     (not (null predicate-fn-lst))
+                     (listp predicate-fn-lst))
+                predicate-fn-lst
+              (mapcar 'caddr
+                      (remove 'nil
+                              (mapcar (lambda (x) (unless (null (car x)) x))
+                                      jiralib-worklog-import--filters-alist)))))
       ;; final condition/sanity checks before processing
       (cond
        ;; pass cases, don't apply filters, return unaltered worklog-obj
        ((or (not (boundp 'predicate-fn-lst)) (not (listp predicate-fn-lst)) (null predicate-fn-lst))
-	worklog-obj)
+        worklog-obj)
        ;; default-case, apply worklog filters and return only matching worklogs
        (t
-	(setq worklogs (funcall unwrap-worklog-records-fn worklogs))
-	(while (setq predicate-fn (pop predicate-fn-lst))
-	  (setq worklogs (mapcar predicate-fn worklogs)))
-	(funcall rewrap-worklog-records-fn worklogs))))))
+        (setq worklogs (funcall unwrap-worklog-records-fn worklogs))
+        (while (setq predicate-fn (pop predicate-fn-lst))
+          (setq worklogs (mapcar predicate-fn worklogs)))
+        (funcall rewrap-worklog-records-fn worklogs))))))
 
 
 (defun jiralib-get-boards ()
@@ -1083,21 +1083,21 @@ results using paging and return results.
 VALUES-KEY - key of the actual reply data in the reply assoc list."
   (setq jiralib-complete-callback nil)
   (let ((not-last t)
-	(start-at 0)
-	;; 50 is server side maximum
-	(max-results 10)
-	(values ()))
+        (start-at 0)
+        ;; 50 is server side maximum
+        (max-results 10)
+        (values ()))
     (while not-last
       (let* ((reply-alist (jiralib--rest-call-it
-			   (jiralib--agile-add-paging-params api  max-results start-at)))
-	     (values-array (cdr (assoc values-key reply-alist)))
-	     (num-entries (length values-array))
-	     (total (cdr (assq 'total reply-alist))))
-	(setf values (append values (append values-array nil)))
-	(setf start-at (+ start-at num-entries))
-	(setf not-last (and (>  num-entries 0)
-			    (or (not total) ;; not always returned
-				(> total start-at))))))
+                           (jiralib--agile-add-paging-params api  max-results start-at)))
+             (values-array (cdr (assoc values-key reply-alist)))
+             (num-entries (length values-array))
+             (total (cdr (assq 'total reply-alist))))
+        (setf values (append values (append values-array nil)))
+        (setf start-at (+ start-at num-entries))
+        (setf not-last (and (>  num-entries 0)
+                            (or (not total) ;; not always returned
+                                (> total start-at))))))
     values))
 
 (defun jiralib--agile-call-async  (api values-key)
@@ -1117,31 +1117,31 @@ VALUES-KEY - key of the actual reply data in the reply assoc list."
        (complete-callback jiralib-complete-callback))
     ;; setup new callback to be called after each page
     (setf jiralib-complete-callback
-	  (cl-function
-	   (lambda  (&rest data &allow-other-keys)
-	     (condition-case err
-		 (let* ((reply-alist (cl-getf data :data))
-			(values-array (cdr (assoc vk reply-alist)))
-			(num-entries (length values-array))
-			(total (cdr (assq 'total reply-alist))))
-		   (setf values-list (append values-list (append values-array nil)))
-		   (setf start-at (+ start-at num-entries))
-		   (message "jiralib agile retrieve: got %d values%s%s"
-			    start-at
-			    (if total " of " "")
-			    (if total (int-to-string total) ""))
-		   (if (and (>  num-entries 0)
-  			    (or (not total) ; not always returned
-				(> total start-at)))
-		       (jiralib--rest-call-it
-			(jiralib--agile-add-paging-params url  max-results start-at))
-		     (progn
-		       ;; last page: call originall callback
-		       (message "jiralib agile retrieve: calling callback")
-		       (setf jiralib-complete-callback complete-callback)
-		       (funcall jiralib-complete-callback
-			     :data  (list (cons vk  values-list)))
-		       (message "jiralib agile retrieve: all done"))))
+          (cl-function
+           (lambda  (&rest data &allow-other-keys)
+             (condition-case err
+                 (let* ((reply-alist (cl-getf data :data))
+                        (values-array (cdr (assoc vk reply-alist)))
+                        (num-entries (length values-array))
+                        (total (cdr (assq 'total reply-alist))))
+                   (setf values-list (append values-list (append values-array nil)))
+                   (setf start-at (+ start-at num-entries))
+                   (message "jiralib agile retrieve: got %d values%s%s"
+                            start-at
+                            (if total " of " "")
+                            (if total (int-to-string total) ""))
+                   (if (and (>  num-entries 0)
+                            (or (not total) ; not always returned
+                                (> total start-at)))
+                       (jiralib--rest-call-it
+                        (jiralib--agile-add-paging-params url  max-results start-at))
+                     (progn
+                       ;; last page: call originall callback
+                       (message "jiralib agile retrieve: calling callback")
+                       (setf jiralib-complete-callback complete-callback)
+                       (funcall jiralib-complete-callback
+                                :data  (list (cons vk  values-list)))
+                       (message "jiralib agile retrieve: all done"))))
                ('error (message (format "jiralib agile retrieve: caught error: %s" err)))))))
     (jiralib--rest-call-it
      (jiralib--agile-add-paging-params api  max-results start-at))))

--- a/org-jira.el
+++ b/org-jira.el
@@ -464,12 +464,12 @@ to change the property names this sets."
   "Kill line, to tags or end of line."
   (cond
    ((or (not org-special-ctrl-k)
-	(bolp)
-	(not (org-at-heading-p)))
+        (bolp)
+        (not (org-at-heading-p)))
     (when (and (get-char-property (min (point-max) (point-at-eol)) 'invisible)
-	       org-ctrl-k-protect-subtree
-	       (or (eq org-ctrl-k-protect-subtree 'error)
-		   (not (y-or-n-p "Kill hidden subtree along with headline? "))))
+               org-ctrl-k-protect-subtree
+               (or (eq org-ctrl-k-protect-subtree 'error)
+                   (not (y-or-n-p "Kill hidden subtree along with headline? "))))
       (user-error "C-k aborted as it would kill a hidden subtree"))
     (call-interactively
      (if (bound-and-true-p visual-line-mode) 'kill-visual-line 'org-jira-kill-line)))
@@ -1108,41 +1108,41 @@ Expects input in format such as: [2017-04-05 Wed 01:00]--[2017-04-05 Wed 01:46] 
         (let ((comments (org-jira-find-value data 'comments)))
           (mapc
            (lambda (comment)
-        ;; First, make sure we're in the proper buffer (logic copied from org-jira-get-issues.
-        (let* ((proj-key (replace-regexp-in-string "-.*" "" issue-id))
-               (project-file (expand-file-name (concat proj-key ".org") org-jira-working-dir))
-               (project-buffer (or (find-buffer-visiting project-file)
-                                  (find-file project-file))))
-          (with-current-buffer project-buffer
-             (ensure-on-issue-id
-              issue-id
-              (let* ((comment-id (org-jira-get-comment-id comment))
-                     (comment-author (or (car (rassoc
-                                               (org-jira-get-comment-author comment)
-                                               org-jira-users))
-                                         (org-jira-get-comment-author comment)))
-                     (comment-headline (format "Comment: %s" comment-author)))
-                (setq p (org-find-entry-with-id comment-id))
-                (when (and p (>= p (point-min))
-                           (<= p (point-max)))
-                  (goto-char p)
-                  (org-narrow-to-subtree)
-                  (delete-region (point-min) (point-max)))
-                (goto-char (point-max))
-                (unless (looking-at "^")
-                  (insert "\n"))
-                (insert "*** ")
-                (org-jira-insert comment-headline "\n")
-                (org-narrow-to-subtree)
-                (org-jira-entry-put (point) "ID" comment-id)
-                (let ((created (org-jira-get-comment-val 'created comment))
-                      (updated (org-jira-get-comment-val 'updated comment)))
-                  (org-jira-entry-put (point) "created" created)
-                  (unless (string= created updated)
-                    (org-jira-entry-put (point) "updated" updated)))
-                (goto-char (point-max))
-                ;;  Insert 2 spaces of indentation so Jira markup won't cause org-markup
-                (org-jira-insert (replace-regexp-in-string "^" "  " (or (org-jira-find-value comment 'body) ""))))))))
+             ;; First, make sure we're in the proper buffer (logic copied from org-jira-get-issues.
+             (let* ((proj-key (replace-regexp-in-string "-.*" "" issue-id))
+                    (project-file (expand-file-name (concat proj-key ".org") org-jira-working-dir))
+                    (project-buffer (or (find-buffer-visiting project-file)
+                                        (find-file project-file))))
+               (with-current-buffer project-buffer
+                 (ensure-on-issue-id
+                  issue-id
+                  (let* ((comment-id (org-jira-get-comment-id comment))
+                         (comment-author (or (car (rassoc
+                                                   (org-jira-get-comment-author comment)
+                                                   org-jira-users))
+                                             (org-jira-get-comment-author comment)))
+                         (comment-headline (format "Comment: %s" comment-author)))
+                    (setq p (org-find-entry-with-id comment-id))
+                    (when (and p (>= p (point-min))
+                               (<= p (point-max)))
+                      (goto-char p)
+                      (org-narrow-to-subtree)
+                      (delete-region (point-min) (point-max)))
+                    (goto-char (point-max))
+                    (unless (looking-at "^")
+                      (insert "\n"))
+                    (insert "*** ")
+                    (org-jira-insert comment-headline "\n")
+                    (org-narrow-to-subtree)
+                    (org-jira-entry-put (point) "ID" comment-id)
+                    (let ((created (org-jira-get-comment-val 'created comment))
+                          (updated (org-jira-get-comment-val 'updated comment)))
+                      (org-jira-entry-put (point) "created" created)
+                      (unless (string= created updated)
+                        (org-jira-entry-put (point) "updated" updated)))
+                    (goto-char (point-max))
+                    ;;  Insert 2 spaces of indentation so Jira markup won't cause org-markup
+                    (org-jira-insert (replace-regexp-in-string "^" "  " (or (org-jira-find-value comment 'body) ""))))))))
            (cl-mapcan
             (lambda (comment)
               ;; Allow user to specify a list of excluded usernames for
@@ -1189,52 +1189,52 @@ purpose of wiping an old subtree."
        (save-excursion
          (cl-function
           (lambda (&key data &allow-other-keys)
-        ;; First, make sure we're in the proper buffer (logic copied from org-jira-get-issues.
-        (let* ((proj-key (replace-regexp-in-string "-.*" "" issue-id))
-               (project-file (expand-file-name (concat proj-key ".org") org-jira-working-dir))
-               (project-buffer (or (find-buffer-visiting project-file)
-                                  (find-file project-file))))
-          (with-current-buffer project-buffer
-            ;; delete old attachment node
-            (ensure-on-issue
-             (if (org-goto-first-child)
-                 (while (org-goto-sibling)
-                   (forward-thing 'whitespace)
-                   (when (looking-at "Attachments:")
-                     (org-jira-delete-subtree)))))
-            (let ((attachments (org-jira-find-value data 'fields 'attachment)))
-              (when (not (zerop (length attachments)))
+            ;; First, make sure we're in the proper buffer (logic copied from org-jira-get-issues.
+            (let* ((proj-key (replace-regexp-in-string "-.*" "" issue-id))
+                   (project-file (expand-file-name (concat proj-key ".org") org-jira-working-dir))
+                   (project-buffer (or (find-buffer-visiting project-file)
+                                       (find-file project-file))))
+              (with-current-buffer project-buffer
+                ;; delete old attachment node
                 (ensure-on-issue
                  (if (org-goto-first-child)
-                     (progn
-                       (while (org-goto-sibling))
-                       (org-insert-heading-after-current))
-                   (org-insert-subheading nil))
+                     (while (org-goto-sibling)
+                       (forward-thing 'whitespace)
+                       (when (looking-at "Attachments:")
+                         (org-jira-delete-subtree)))))
+                (let ((attachments (org-jira-find-value data 'fields 'attachment)))
+                  (when (not (zerop (length attachments)))
+                    (ensure-on-issue
+                     (if (org-goto-first-child)
+                         (progn
+                           (while (org-goto-sibling))
+                           (org-insert-heading-after-current))
+                       (org-insert-subheading nil))
 
-                 (insert "Attachments:")
-                 (mapc
-                  (lambda (attachment)
-                    (let ((attachment-id (org-jira-get-comment-id attachment))
-                          (author (org-jira-get-comment-author attachment))
-                          (created (org-jira-transform-time-format
-                                    (org-jira-find-value attachment 'created)))
-                          (size (org-jira-find-value attachment 'size))
-                          (mimeType (org-jira-find-value attachment 'mimeType))
-                          (content (org-jira-find-value attachment 'content))
-                          (filename (org-jira-find-value attachment 'filename)))
-                      (if (looking-back "Attachments:")
-                          (org-insert-subheading nil)
-                        (org-insert-heading-respect-content))
-                      (insert "[[" content "][" filename "]]")
-                      (org-narrow-to-subtree)
-                      (org-jira-entry-put (point) "ID" attachment-id)
-                      (org-jira-entry-put (point) "Author" author)
-                      (org-jira-entry-put (point) "Name" filename)
-                      (org-jira-entry-put (point) "Created" created)
-                      (org-jira-entry-put (point) "Size" (ls-lisp-format-file-size size t))
-                      (org-jira-entry-put (point) "Content" content)
-                      (widen)))
-                  attachments)))))))))))))
+                     (insert "Attachments:")
+                     (mapc
+                      (lambda (attachment)
+                        (let ((attachment-id (org-jira-get-comment-id attachment))
+                              (author (org-jira-get-comment-author attachment))
+                              (created (org-jira-transform-time-format
+                                        (org-jira-find-value attachment 'created)))
+                              (size (org-jira-find-value attachment 'size))
+                              (mimeType (org-jira-find-value attachment 'mimeType))
+                              (content (org-jira-find-value attachment 'content))
+                              (filename (org-jira-find-value attachment 'filename)))
+                          (if (looking-back "Attachments:")
+                              (org-insert-subheading nil)
+                            (org-insert-heading-respect-content))
+                          (insert "[[" content "][" filename "]]")
+                          (org-narrow-to-subtree)
+                          (org-jira-entry-put (point) "ID" attachment-id)
+                          (org-jira-entry-put (point) "Author" author)
+                          (org-jira-entry-put (point) "Name" filename)
+                          (org-jira-entry-put (point) "Created" created)
+                          (org-jira-entry-put (point) "Size" (ls-lisp-format-file-size size t))
+                          (org-jira-entry-put (point) "Content" content)
+                          (widen)))
+                      attachments)))))))))))))
 
 (defun org-jira-sort-org-clocks (clocks)
   "Given a CLOCKS list, sort it by start date descending."
@@ -1259,7 +1259,7 @@ purpose of wiping an old subtree."
         (let* ((proj-key (replace-regexp-in-string "-.*" "" issue-id))
                (project-file (expand-file-name (concat proj-key ".org") org-jira-working-dir))
                (project-buffer (or (find-buffer-visiting project-file)
-                                  (find-file project-file))))
+                                   (find-file project-file))))
           (with-current-buffer project-buffer
             (ensure-on-issue-id
              issue-id
@@ -1332,12 +1332,12 @@ purpose of wiping an old subtree."
 (defun org-jira-read-board ()
   "Read board name. Returns cons pair (name . integer-id)"
   (let* ((boards-alist
-	  (jiralib-make-assoc-list (jiralib-get-boards) 'name 'id))
-	 (board-name
-	  (completing-read "Boards: "  boards-alist
-			   nil  t  nil
-			   'org-jira-boards-read-history
-			   (car org-jira-boards-read-history))))
+          (jiralib-make-assoc-list (jiralib-get-boards) 'name 'id))
+         (board-name
+          (completing-read "Boards: "  boards-alist
+                           nil  t  nil
+                           'org-jira-boards-read-history
+                           (car org-jira-boards-read-history))))
     (assoc board-name boards-alist)))
 
 (defun org-jira-read-component (project)
@@ -1978,7 +1978,7 @@ See `org-jira-get-issues-from-filter'."
   "Get list of ISSUES from agile board."
   (interactive)
   (let* ((board (org-jira-read-board))
-	 (board-id (cdr board)))
+         (board-id (cdr board)))
     (jiralib-get-board-issues board-id org-jira-get-issue-list-callback)))
 
 ;;;###autoload
@@ -1986,7 +1986,7 @@ See `org-jira-get-issues-from-filter'."
   "Get list of ISSUES from agile board, head only."
   (interactive)
   (let* ((board (org-jira-read-board))
-	 (board-id (cdr board)))
+         (board-id (cdr board)))
     (org-jira-get-issues-headonly (jiralib-get-board-issues board-id))))
 
 ;;;###autoload
@@ -1994,45 +1994,45 @@ See `org-jira-get-issues-from-filter'."
   "Get list of projects."
   (interactive)
   (lexical-let* ((boards-file (expand-file-name "boards-list.org" org-jira-working-dir))
-		 (existing-buffer (find-buffer-visiting boards-file))
-		 (boards (jiralib-get-boards)))
+                 (existing-buffer (find-buffer-visiting boards-file))
+                 (boards (jiralib-get-boards)))
     (save-excursion
       (if existing-buffer
-	  (pop-to-buffer (set-buffer existing-buffer))
+          (pop-to-buffer (set-buffer existing-buffer))
         (find-file boards-file))
       (org-jira-mode t)
       (org-save-outline-visibility t
-	(outline-show-all)
-	(save-restriction
-	  (mapc (lambda (board)
-		  (widen)
-		  (goto-char (point-min))
-		  (let* ((board-id (org-jira-find-value board 'id))
-			 (board-name (org-jira-find-value board 'name))
-			 (board-url
-			  (format "%s/secure/RapidBoard.jspa?rapidView=%d"
-				  (replace-regexp-in-string "/*$" "" jiralib-url) board-id))
-			 (board-headline
-			  (format "Board: [[%s][%s]]" board-url board-name))
-			 (headline-pos (org-find-exact-headline-in-buffer
-					board-headline (current-buffer) t)))
-		    (if (and headline-pos (>= headline-pos (point-min))
+        (outline-show-all)
+        (save-restriction
+          (mapc (lambda (board)
+                  (widen)
+                  (goto-char (point-min))
+                  (let* ((board-id (org-jira-find-value board 'id))
+                         (board-name (org-jira-find-value board 'name))
+                         (board-url
+                          (format "%s/secure/RapidBoard.jspa?rapidView=%d"
+                                  (replace-regexp-in-string "/*$" "" jiralib-url) board-id))
+                         (board-headline
+                          (format "Board: [[%s][%s]]" board-url board-name))
+                         (headline-pos (org-find-exact-headline-in-buffer
+                                        board-headline (current-buffer) t)))
+                    (if (and headline-pos (>= headline-pos (point-min))
                              (<= headline-pos (point-max)))
-			(progn
+                        (progn
                           (goto-char headline-pos)
                           (org-narrow-to-subtree)
                           (end-of-line))
                       (goto-char (point-max))
                       (unless (looking-at "^")
-			(insert "\n"))
+                        (insert "\n"))
                       (insert "* ")
                       (org-jira-insert board-headline)
                       (org-narrow-to-subtree))
                     (org-jira-entry-put (point) "name" board-name)
                     (org-jira-entry-put (point) "type" (cdr (assoc 'type board)))
-		    (org-jira-entry-put (point) "url" board-url)
+                    (org-jira-entry-put (point) "url" board-url)
                     (org-jira-entry-put (point) "ID" (number-to-string board-id))))
-		boards))))))
+                boards))))))
 
 (defun org-jira-get-keyword-from-status (status)
   "Gets an 'org-mode' keyword corresponding to a given jira STATUS."


### PR DESCRIPTION
There's an emacs package for editorconfig support https://github.com/editorconfig/editorconfig-emacs so that all the contributors use the same whitespace settings.

This makes contributing easier as we will avoid unnecessary whitespace issues (like pull request with tab<->space changes and so on)