### PR TITLE
Extract function for generating task headline.

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -820,6 +820,13 @@ See`org-jira-get-issue-list'"
     (save-window-excursion
       (org-jira--render-issues-from-issue-list issues))))
 
+(defun org-jira--get-org-headline-from-issue (issue)
+  "Get org task headline from Jira ISSUE.
+
+The returned string will be used as the headline for the org task
+representing ISSUE."
+  (org-jira-get-issue-summary issue))
+
 (defun org-jira--render-issues-from-issue-list (issues)
   "Add the issues from ISSUES list into the org file(s)."
   (let (project-buffer)
@@ -852,7 +859,8 @@ See`org-jira-get-issue-list'"
                           (insert "\n"))
                         (insert "** "))
                       (let ((status (org-jira-get-issue-val 'status issue)))
-                        (org-jira-insert (concat (org-jira-get-keyword-from-status status) " " issue-headline)))
+                        (org-jira-insert (concat (org-jira-get-keyword-from-status status) " "
+                                                 (org-jira--get-org-headline-from-issue issue))))
                       (save-excursion
                         (unless (search-forward "\n" (point-max) 1)
                           (insert "\n")))


### PR DESCRIPTION
This is useful for cases where user wants to customize how the
headline is generated.

At my job we also use toggl for time tracking for which I use https://github.com/mbork/org-toggl to keep it in sync.  I like to have the issue ID at the beginning of the toggle task so our managers can keep track.

So this abstraction allows me to advice the process.