### PR TITLE
Fix jiralib-user-login-name is always nil

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -240,8 +240,8 @@ After a successful login, store the authentication token in
     (unless jiralib-wsdl
       (jiralib-load-wsdl))
     (setq jiralib-token
-          (car (soap-invoke jiralib-wsdl "jirasoapservice-v2" "login" username password)))
-    (setq jiralib-user-login-name username)))
+          (car (soap-invoke jiralib-wsdl "jirasoapservice-v2" "login" username password))))
+    (setq jiralib-user-login-name username))
 
 (defvar jiralib-complete-callback nil)
 


### PR DESCRIPTION
As long as there is no other solution, I suggest setting `jiralib-user-login-name` in `jiralib-login` always.