### PR TITLE
Fix 'username' in org-jira-get-assignable-users

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -495,7 +495,7 @@ Entry to this mode calls the value of `org-jira-mode-hook'."
    org-jira-users
    (mapcar (lambda (user)
              (cons (org-jira-decode (cdr (assoc 'displayName user)))
-                   (org-jira-decode (cdr (assoc 'key user)))))
+                   (org-jira-decode (cdr (assoc 'name user)))))
            (jiralib-get-users project-key))))
 
 (defun org-jira-entry-put (pom property value)


### PR DESCRIPTION
In jiralib-use-restapi (getUser) we have a "username" filter not a "key" filter.

Fix #145 