### PR TITLE
Pass port as string to auth-source-search

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -230,7 +230,8 @@ After a successful login, store the authentication token in
                                              :host (if (string= jiralib-host "")
                                                        (url-host (url-generic-parse-url jiralib-url))
                                                      jiralib-host)
-                                             :port (url-port (url-generic-parse-url jiralib-url))
+                                             ;; secrets.el wouldn’t accept a number.
+                                             :port (number-to-string (url-port (url-generic-parse-url jiralib-url)))
                                              :require '(:user :secret)
                                              :create t)))
            user secret)


### PR DESCRIPTION
This is a change analogous to [commit f9d87dd8791d4e77929f21e in Emacs](http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=f9d87dd8791d4e77929f21e4f73d92ef966722cc).

See [bug #20541 in Emacs](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=20541) for details.