### PR TITLE
Make it more user friendly when progressing issue.

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -1583,7 +1583,6 @@ that should be bound to an issue."
              (or (org-entry-get (point) key)
                  ""))))))
 
-(defvar org-jira-actions-history nil)
 (defun org-jira-read-action (actions)
   "Read issue workflow progress ACTIONS."
   (let ((action (completing-read
@@ -1591,10 +1590,10 @@ that should be bound to an issue."
                  (mapcar 'cdr actions)
                  nil
                  t
-                 nil
-                 'org-jira-actions-history
-                 (car org-jira-actions-history))))
-    (car (rassoc action actions))))
+                 nil)))
+    (or
+     (car (rassoc action actions))
+     (user-error "You specified an empty action, the valid actions are: %s" (mapcar 'cdr actions)))))
 
 (defvar org-jira-fields-history nil)
 (defun org-jira-read-field (fields)


### PR DESCRIPTION
I was confused when progressing issues by an invalid action in the
actions history.

The actions history does not make much sense I think, given that
different status has different next step actions.

So I removed the history, and throw an error when user specified an
empty action.

Signed-off-by: Bao Haojun <baohaojun@gmail.com>