### PR TITLE
Fix newline in basic auth HTTP header

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -248,7 +248,7 @@ After a successful login, store the authentication token in
                    sec)))
          (list user secret)))))
   (if jiralib-use-restapi
-      (setq jiralib-token `("Authorization" . , (format "Basic %s" (base64-encode-string (concat username ":" password)))))
+      (setq jiralib-token `("Authorization" . , (format "Basic %s" (base64-encode-string (concat username ":" password) t))))
     (unless jiralib-wsdl
       (jiralib-load-wsdl))
     (setq jiralib-token


### PR DESCRIPTION
Hi! I noticed this issue earlier where I couldn't authenticate using basic auth because `base64-encode-string` was splitting the auth header value with a newline. This is the default behaviour if `NO-LINE-BREAK` is not provided.

I've run `make test` to confirm that this change doesn't break any tests, but have not looked into whether there are valid cases where the newline would be required.

I've also not confirmed what the definition of "long lines" is in the C source.

Have not raised an issue for this yet as I'm in a rush but will try to do so later.
