### PR TITLE
Support the labels field (issue #83)

### DIFF
--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -94,6 +94,7 @@
 (defclass org-jira-sdk-issue (org-jira-sdk-record)
   ((assignee :type (or null string) :initarg :assignee)
    (components :type string :initarg :components)
+   (labels :type string :initarg :labels)
    (created :type string :initarg :created)
    (description :type (or null string) :initarg :description)
    (duedate :type (or null string) :initarg :duedate)
@@ -146,6 +147,7 @@
     (org-jira-sdk-issue
      :assignee (path '(fields assignee name))
      :components (mapconcat (lambda (c) (org-jira-sdk-path c '(name))) (path '(fields components)) ", ")
+     :labels (mapconcat (lambda (c) (format "%s" c)) (map 'list #'identity (path '(fields labels))) ", ")
      :created (path '(fields created))     ; confirm
      :description (or (path '(fields description)) "")
      :duedate (path '(fields duedate))         ; confirm

--- a/org-jira.el
+++ b/org-jira.el
@@ -687,6 +687,10 @@ to change the property names this sets."
      (org-jira-find-value comp 'name))
    (org-jira-find-value issue 'fields 'components) ", "))
 
+(defun org-jira-get-issue-labels (issue)
+  "Return the labels the ISSUE belongs to."
+  (org-jira-find-value issue 'fields 'labels))
+
 (defun org-jira-decode (data)
   "Decode text DATA.
 
@@ -832,6 +836,8 @@ Re-create it with CLOCKS.  This is used for worklogs."
       (setq tmp ""))
     (cond ((eq key 'components)
            (org-jira-get-issue-components issue))
+          ((eq key 'labels)
+           (org-jira-get-issue-labels issue))
           ((member key '(created updated startDate))
            (org-jira-transform-time-format tmp))
           ((eq key 'status)
@@ -1095,7 +1101,7 @@ ORG-JIRA-PROJ-KEY-OVERRIDE being set before and after running."
                       (when (or (and val (not (string= val "")))
                                 (eq entry 'assignee)) ;; Always show assignee
                         (org-jira-entry-put (point) (symbol-name entry) val))))
-                  '(assignee filename reporter type priority resolution status components created updated))
+                  '(assignee filename reporter type priority labels resolution status components created updated))
 
             (org-jira-entry-put (point) "ID" issue-id)
             (org-jira-entry-put (point) "CUSTOM_ID" issue-id)


### PR DESCRIPTION
Hi, perhaps you are so busy so I would like to create PR to solve the #83. 
This PR is not best implenmentation. Please review and improve it.

This PR will support the labels field will be rendered in `:PROPERTIES:`

```
   :PROPERTIES:
   :assignee: me...
   :type:     Bug
   :priority: Low
   :labels:   Patch, Security
```
