### PR TITLE
A fix for subtask creation

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -892,12 +892,11 @@ Return nil if the field is not found"
 ISSUE is a Hashtable object."
   (jiralib-call "createIssue" nil issue))
 
-(defun jiralib-create-subtask (subtask parent-issue-id)
+(defun jiralib-create-subtask (subtask)
   "Create SUBTASK for issue with PARENT-ISSUE-ID.
 
 SUBTASK is a Hashtable object."
-  (jiralib-call "createIssueWithParent" nil subtask parent-issue-id))
-
+  (jiralib-call "createIssueWithParent" nil subtask))
 
 (defvar jiralib-subtask-types-cache nil)
 

--- a/jiralib.el
+++ b/jiralib.el
@@ -351,8 +351,13 @@ request.el, so if at all possible, it should be avoided."
                         :data (json-encode (first params)))))
          (jiralib--rest-call-it (cdr (assoc 'self response)) :type "GET")
          ))
-      ('createIssueWithParent (jiralib--rest-call-it
-                               ))
+      ('createIssueWithParent
+       (let ((response (jiralib--rest-call-it
+                        "/rest/api/2/issue"
+                        :type "POST"
+                        :data (json-encode (first params)))))
+         (jiralib--rest-call-it (cdr (assoc 'self response)) :type "GET")
+         ))
       ('editComment (jiralib--rest-call-it
                      (format "/rest/api/2/issue/%s/comment/%s" (first params) (second params))
                      :data (json-encode `((body . ,(third params))))

--- a/jiralib.el
+++ b/jiralib.el
@@ -313,6 +313,7 @@ request.el, so if at all possible, it should be avoided."
     (case (intern method)
       ('getStatuses (jiralib--rest-call-it "/rest/api/2/status"))
       ('getIssueTypes (jiralib--rest-call-it "/rest/api/2/issuetype"))
+      ('getSubTaskIssueTypes (jiralib--rest-call-it "/rest/api/2/issuetype"))
       ('getIssueTypesByProject
        (let ((response (jiralib--rest-call-it (format "/rest/api/2/project/%s" (first params)))))
          (cl-coerce (cdr (assoc 'issueTypes response)) 'list)))

--- a/org-jira.el
+++ b/org-jira.el
@@ -1712,7 +1712,7 @@ that should be bound to an issue."
    'org-jira-type-read-history
    (car org-jira-type-read-history)))
 
-(defun org-jira-get-issue-struct (project type summary description)
+(defun org-jira-get-issue-struct (project type summary description &optional parent-id)
   "Create an issue struct for PROJECT, of TYPE, with SUMMARY and DESCRIPTION."
   (if (or (equal project "")
           (equal type "")
@@ -1725,6 +1725,7 @@ that should be bound to an issue."
          (ticket-struct
           `((fields
              (project (key . ,project))
+             (parent (key . ,parent-id))
              (issuetype (id . ,(car (rassoc type (if (and (boundp 'parent-id) parent-id)
                                                      (jiralib-get-subtask-types)
                                                    (jiralib-get-issue-types))))))
@@ -1766,8 +1767,8 @@ that should be bound to an issue."
           (equal summary ""))
       (error "Must provide all information!"))
   (let* ((parent-id (org-jira-parse-issue-id))
-         (ticket-struct (org-jira-get-issue-struct project type summary description)))
-    (org-jira-get-issues (list (jiralib-create-subtask ticket-struct parent-id)))))
+         (ticket-struct (org-jira-get-issue-struct project type summary description parent-id)))
+    (org-jira-get-issues (list (jiralib-create-subtask ticket-struct)))))
 
 (defun org-jira-strip-string (str)
   "Remove the beginning and ending white space for a string STR."


### PR DESCRIPTION
**disclaimer:** This is the first time I have ever created a PR on github and my first time with an elisp codebase.

I was using org-jira for a while just to view my tasks and keep some notes on them, but when I started wanting to create issues from within org-jira I hit an issue. Creating subtasks did not work at all. I realized that `createIssueWithParent` was not implemented in `jiralib-call` and the id of the parent task needed to be part of the request fields.

My fix for this was to add the parent-id as an option argument to `org-jira-get-issue-struct` in order to include the parent in the api request. This removed the need to pass parent-id to `jiralib-create-subtask` and the `jiralib-call "createIssueWithParent"` call. Because of this there is virtually no difference between `jiralib-create-subtask` and `jiralib-create-issue`.

Please let me know if there is anything I should change about this PR.