### PR TITLE
Fix error when creating a new issue

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -1697,7 +1697,7 @@ that should be bound to an issue."
      nil
      t
      nil
-     initial-input
+     'initial-input
      (car initial-input))))
 
 (defun org-jira-read-subtask-type ()


### PR DESCRIPTION
When I was trying to create an issue I would get an error in the completing-read call. Looks like the initial-input variable was not being passed in properly.