### PR TITLE
Get issue type id by project when creating issues

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -1727,7 +1727,7 @@ that should be bound to an issue."
              (parent (key . ,parent-id))
              (issuetype (id . ,(car (rassoc type (if (and (boundp 'parent-id) parent-id)
                                                      (jiralib-get-subtask-types)
-                                                   (jiralib-get-issue-types))))))
+                                                   (jiralib-get-issue-types-by-project project))))))
              (summary . ,(format "%s%s" summary
                                  (if (and (boundp 'parent-id) parent-id)
                                      (format " (subtask of [jira:%s])" parent-id)


### PR DESCRIPTION
Large JIRA users may have many issue IDs with the same name; only the
ID associated with a specific project is valid when creating an issue
for that project, so use issue-types-by-id when creating an issue