### PR TITLE
Allow to disable comments downloading during issue rendering

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -313,6 +313,11 @@ See `org-default-priority' for more info."
   :group 'org-jira
   :type '(alist :value-type plist))
 
+(defcustom org-jira-download-comments t
+  "Set to nil if you don't want to update comments during issue rendering."
+  :group 'org-jira
+  :type 'boolean)
+
 (defvar org-jira-serv nil
   "Parameters of the currently selected blog.")
 
@@ -1143,10 +1148,12 @@ ORG-JIRA-PROJ-KEY-OVERRIDE being set before and after running."
                      (format "%s" (slot-value Issue heading-entry)))))))
              '(description))
 
-            (org-jira-update-comments-for-issue Issue)
+            (when org-jira-download-comments
+              (org-jira-update-comments-for-issue Issue)
 
-            ;; FIXME: Re-enable when attachments are not erroring.
-            ;;(org-jira-update-attachments-for-current-issue)
+              ;; FIXME: Re-enable when attachments are not erroring.
+              ;;(org-jira-update-attachments-for-current-issue)
+              )
 
             ;; only sync worklog clocks when the user sets it to be so.
             (when org-jira-worklog-sync-p


### PR DESCRIPTION
This change with org-jira-download-comments set to nil aims to be
something in between org-jira-get-issues-headonly call and
org-jira-get-issues.

Some users may not find downloading issues comments to be very useful, as
they don't use org-jira package for reading comments. In that case
rendering comments could bring too much delay to synchronizations process
and increase size of the org-mode file without significant reason. This
mostly problem with huge issue lists.

Although these is org-jira-get-issues-headonly for rendering only
headlines of the issues, it could be not enough, as this renderer don't
download anything except headline itself. In other words various issue
properties are not downloaded.