### PR TITLE
Incorporate changes to JIRA API

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -314,7 +314,7 @@ request.el, so if at all possible, it should be avoided."
       ('getIssueTypesByProject
        (let ((response (jiralib--rest-call-it (format "/rest/api/2/project/%s" (first params)))))
          (cl-coerce (cdr (assoc 'issueTypes response)) 'list)))
-      ('getUser (jiralib--rest-call-it "/rest/api/2/user" :params `((username . ,(first params)))))
+      ('getUser (jiralib--rest-call-it "/rest/api/2/user" :params `((accountId . ,(first params)))))
       ('getVersions (jiralib--rest-call-it (format "/rest/api/2/project/%s/versions" (first params))))
 
       ;; Worklog calls
@@ -522,6 +522,31 @@ emacs-lisp"
               remote-field-values)))
 
     (apply 'vector (nreverse remote-field-values))))
+
+(defvar jiralib-subvalue-map
+  '((assignee . displayName)
+    (creator . displayName)
+    (priority . name)
+    (issuetype . name)))
+
+(defun jiralib-flatten-data (data)
+  "Extracts the displayName Value an creates a tuple of ((car list) . subvalue).
+If no key is given, returns list as-is."
+  (loop for item in data collect
+        (cond ((and (listp (cdr item))
+                    (assoc (car item) jiralib-subvalue-map))
+               (cons (car item) (cdr (assoc (cdr (assoc (car item) jiralib-subvalue-map)) (cdr item)))))
+              ((listp (cdr item))
+               (cons (car item) (jiralib-flatten-data (cdr item))))
+              (t item))))
+
+
+
+
+
+
+
+
 
 ;;;; Wrappers around JIRA methods
 
@@ -850,15 +875,26 @@ Return nil if the field is not found"
           (setf name (cdr (assoc 'name type)))))
     name))
 
-(defun jiralib-get-user-fullname (username)
-  "Return the full name (display name) of the user with USERNAME."
-  (if (assoc username jiralib-user-fullnames)
-      (cdr (assoc username jiralib-user-fullnames))
-    (progn
-      (let ((user (jiralib-get-user username)))
-        (setf jiralib-user-fullnames (append jiralib-user-fullnames (list (cons username (cdr (assoc 'fullname user))))))
-        (cdr (assoc 'fullname user))))))
+;; (defun jiralib-get-user-fullname (account-id)
+;;   "Return the full name (display name) of the user with USERNAME."
+  ;; (if (assoc account-id jiralib-user-fullnames)
+  ;;     (cdr (assoc account-id jiralib-user-fullnames))
+  ;;   (progn
+  ;;     (let ((user (jiralib-get-user account-id)))
+  ;;       (setf jiralib-user-fullnames (append jiralib-user-fullnames (list (cons account-id (cdr (assoc 'fullname user))))))
+  ;;       (cdr (assoc 'fullname user))))))
 
+(defun jiralib-get-user-fullname (account-id)
+  "Return the full name (displaName) of the user with accountId."
+  (loop for user in (jiralib-get-users nil)
+        when (rassoc account-id user)
+        return (cdr (assoc 'displayName user))))
+
+(defun jiralib-get-user-account-id (full-name)
+    "Return the account-id (accountId) of the user with displayName."
+  (loop for user in (jiralib-get-users nil)
+        when (rassoc full-name user)
+        return (cdr (assoc 'accountId user))))
 
 (defun jiralib-get-filter (filter-id)
   "Return a filter given its FILTER-ID."
@@ -1010,10 +1046,10 @@ Return no more than MAX-NUM-RESULTS."
   "Return all visible subtask issue types in the system."
   (jiralib-call "getSubTaskIssueTypes" nil))
 
-(defun jiralib-get-user (username)
-  "Return a user's information given their USERNAME."
-  (cond ((eq 0 (length username)) nil) ;; Unassigned
-        (t (jiralib-call "getUser" nil username))))
+(defun jiralib-get-user (account-id)
+  "Return a user's information given their full name."
+  (cond ((eq 0 (length account-id)) nil) ;; Unassigned
+        (t (jiralib-call "getUser" nil account-id))))
 
 (defvar jiralib-users-cache nil "Cached list of users.")
 
@@ -1021,7 +1057,9 @@ Return no more than MAX-NUM-RESULTS."
   "Return assignable users information given the PROJECT-KEY."
   (unless jiralib-users-cache
     (setq jiralib-users-cache
-          (jiralib-call "getUsers" nil project-key)))
+          (jiralib-call "getUsers" nil project-key))
+    (loop for (name . id) in org-jira-users do
+          (setf jiralib-users-cache (append (list (jiralib-get-user id)) jiralib-users-cache))))
   jiralib-users-cache)
 
 (defun jiralib-get-versions (project-key)

--- a/jiralib.el
+++ b/jiralib.el
@@ -523,30 +523,6 @@ emacs-lisp"
 
     (apply 'vector (nreverse remote-field-values))))
 
-(defvar jiralib-subvalue-map
-  '((assignee . displayName)
-    (creator . displayName)
-    (priority . name)
-    (issuetype . name)))
-
-(defun jiralib-flatten-data (data)
-  "Extracts the displayName Value an creates a tuple of ((car list) . subvalue).
-If no key is given, returns list as-is."
-  (loop for item in data collect
-        (cond ((and (listp (cdr item))
-                    (assoc (car item) jiralib-subvalue-map))
-               (cons (car item) (cdr (assoc (cdr (assoc (car item) jiralib-subvalue-map)) (cdr item)))))
-              ((listp (cdr item))
-               (cons (car item) (jiralib-flatten-data (cdr item))))
-              (t item))))
-
-
-
-
-
-
-
-
 
 ;;;; Wrappers around JIRA methods
 

--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -144,7 +144,7 @@
 (cl-defmethod org-jira-sdk-from-data ((rec org-jira-sdk-issue))
   (cl-flet ((path (keys) (org-jira-sdk-path (oref rec data) keys)))
     (org-jira-sdk-issue
-     :assignee (path '(fields assignee name))
+     :assignee (path '(fields assignee displayName))
      :components (mapconcat (lambda (c) (org-jira-sdk-path c '(name))) (path '(fields components)) ", ")
      :labels (mapconcat (lambda (c) (format "%s" c)) (map 'list #'identity (path '(fields labels))) ", ")
      :created (path '(fields created))     ; confirm
@@ -157,7 +157,7 @@
      :issue-id-int (path '(id))
      :priority (path '(fields priority name))
      :proj-key (path '(fields project key))
-     :reporter (path '(fields reporter name)) ; reporter could be an object of its own slot values
+     :reporter (path '(fields reporter displayName)) ; reporter could be an object of its own slot values
      :resolution (path '(fields resolution name))  ; confirm
      :start-date (path '(fields start-date))  ; confirm
      :status (org-jira-decode (path '(fields status name)))

--- a/org-jira.el
+++ b/org-jira.el
@@ -176,7 +176,7 @@ where both are strings.  NEW-FILE-NAME is relative to
   :type '(repeat (string :tag "Jira state name:")))
 
 (defcustom org-jira-users
-  '(("Full Name" . "username"))
+  '(("Full Name" . "account-id"))
   "A list of displayName and key pairs."
   :group 'org-jira
   :type 'list)
@@ -596,7 +596,7 @@ Entry to this mode calls the value of `org-jira-mode-hook'."
    org-jira-users
    (mapcar (lambda (user)
              (cons (org-jira-decode (cdr (assoc 'displayName user)))
-                   (org-jira-decode (cdr (assoc 'name user)))))
+                   (org-jira-decode (cdr (assoc 'accountId user)))))
            (jiralib-get-users project-key))))
 
 (defun org-jira-get-reporter-candidates (project-key)
@@ -605,7 +605,7 @@ Entry to this mode calls the value of `org-jira-mode-hook'."
    org-jira-users
    (mapcar (lambda (user)
              (cons (org-jira-decode (cdr (assoc 'displayName user)))
-                   (org-jira-decode (cdr (assoc 'name user)))))
+                   (org-jira-decode (cdr (assoc 'accountId user)))))
            (jiralib-get-users project-key))))
 
 (defun org-jira-entry-put (pom property value)
@@ -950,7 +950,6 @@ With a prefix argument, allow you to customize the jql.  See
     (when issue-pos
       (goto-char issue-pos)
       (recenter 0))))
-
 ;;;###autoload
 (defun org-jira-get-issues-by-fixversion (fixversion)
   "Get list of issues by FIXVERSION."
@@ -1565,7 +1564,7 @@ purpose of wiping an old subtree."
                           (cdr (rassoc user jira-users)))))
           (when (null reporter)
             (error "No reporter found, this should probably never happen."))
-          (org-jira-update-issue-details issue-id filename :reporter reporter))
+          (org-jira-update-issue-details issue-id filename :reporter (jiralib-get-account-id reporter)))
       (error "Not on an issue"))))
 
 ;;;###autoload
@@ -1586,7 +1585,7 @@ purpose of wiping an old subtree."
                           (cdr (rassoc user jira-users)))))
           (when (null assignee)
             (error "No assignee found, use org-jira-unassign-issue to make the issue unassigned"))
-          (org-jira-update-issue-details issue-id filename :assignee assignee))
+          (org-jira-update-issue-details issue-id filename :assignee (jiralib-get-account-id assignee)))
       (error "Not on an issue"))))
 
 ;;;###autoload
@@ -2105,8 +2104,8 @@ otherwise it should return:
                    (cons 'priority (org-jira-get-id-name-alist org-issue-priority
                                                        (jiralib-get-priorities)))
                    (cons 'description org-issue-description)
-                   (cons 'assignee (jiralib-get-user org-issue-assignee))
-                   (cons 'reporter (jiralib-get-user org-issue-reporter))
+                   (cons 'assignee (list (cons 'id (jiralib-get-account-id org-issue-assignee))))
+                   (cons 'reporter (list (cons 'id (jiralib-get-account-id org-issue-reporter))))
                    (cons 'summary (org-jira-strip-priority-tags (org-jira-get-issue-val-from-org 'summary)))
                    (cons 'issuetype (org-jira-get-id-name-alist org-issue-type
                                                         (jiralib-get-issue-types))))))
@@ -2133,6 +2132,8 @@ otherwise it should return:
               (-> cb-data list org-jira-get-issues))))
          ))
       )))
+
+       
 
 (defun org-jira-parse-issue-id ()
   "Get issue id from org text."


### PR DESCRIPTION
JIRA changed the API to no longer use usernames, but accountIds instead, apparently for privacy reasons. I've tested my changes with JIRA cloud. The API changes date back to 2018, if I didn't misinterpret the documentation. 