### PR TITLE
Update README to include ~/.org-jira directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ has MELPA set up):
 
 Then run `M-x package-install RET org-jira RET` and you're done!
 ### Configuration
+
+Create the `org-jira-working-dir` directory:
+
+```lisp
+(make-directory "~/.org-jira")
+```
+
 In your ~/.emacs, you should set the variable as such:
 
 ```conf


### PR DESCRIPTION
Firstly, thanks for the awesome JIRA integration.
It's saving me a few minutes each day, and over time they add up  :smile: 

I had a few problems retrieving my projects and boards, one of which was that the `~/.org-jira` directory needed to be created.  This wasn't too obvious, as I could retrieve projects and issues without the directory (I assume the buffer isn't backed by a file in this case), but odd things ensued.  This might be related to #215.

What do you think about adding some instructions to the readme?

It might also be worth checking for the directory and printing an error message, or perhaps just creating the directory.