### PR TITLE
Adding type-id to properties in org

### DIFF
--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -110,6 +110,7 @@
    (status :type string :initarg :status)
    (summary :type string :initarg :summary)
    (type :type string :initarg :type)
+   (type-id :type string :initarg :type-id)
    (updated :type string :initarg :updated)
    (data :initarg :data :documentation "The remote Jira data object (alist).")
    (hydrate-fn :initform #'jiralib-get-issue :initarg :hydrate-fn))
@@ -163,6 +164,7 @@
      :status (org-jira-decode (path '(fields status name)))
      :summary (path '(fields summary))
      :type (path '(fields issuetype name))
+     :type-id (path '(fields issuetype id))
      :updated (path '(fields updated))  ; confirm
      ;; TODO: Remove this
      ;; :data (oref rec data)

--- a/org-jira.el
+++ b/org-jira.el
@@ -1115,7 +1115,7 @@ ORG-JIRA-PROJ-KEY-OVERRIDE being set before and after running."
                       (when (or (and val (not (string= val "")))
                                 (eq entry 'assignee)) ;; Always show assignee
                         (org-jira-entry-put (point) (symbol-name entry) val))))
-                  '(assignee filename reporter type priority labels resolution status components created updated))
+                  '(assignee filename reporter type type-id priority labels resolution status components created updated))
 
             (org-jira-entry-put (point) "ID" issue-id)
             (org-jira-entry-put (point) "CUSTOM_ID" issue-id)
@@ -2095,6 +2095,7 @@ otherwise it should return:
            (org-issue-description (org-trim (org-jira-get-issue-val-from-org 'description)))
            (org-issue-priority (org-jira-get-issue-val-from-org 'priority))
            (org-issue-type (org-jira-get-issue-val-from-org 'type))
+           (org-issue-type-id (org-jira-get-issue-val-from-org 'type-id))
            (org-issue-assignee (cl-getf rest :assignee (org-jira-get-issue-val-from-org 'assignee)))
            (org-issue-reporter (cl-getf rest :reporter (org-jira-get-issue-val-from-org 'reporter)))
            (project (replace-regexp-in-string "-[0-9]+" "" issue-id))
@@ -2122,8 +2123,8 @@ otherwise it should return:
                    (cons 'assignee (list (cons 'id (jiralib-get-user-account-id org-issue-assignee))))
                    (cons 'reporter (list (cons 'id (jiralib-get-user-account-id org-issue-reporter))))
                    (cons 'summary (org-jira-strip-priority-tags (org-jira-get-issue-val-from-org 'summary)))
-                   (cons 'issuetype (org-jira-get-id-name-alist org-issue-type
-                                                        (jiralib-get-issue-types))))))
+                   (cons 'issuetype `((id . ,org-issue-type-id)
+      (name . ,org-issue-type))))))
 
 
         ;; If we enable duedate sync and we have a deadline present


### PR DESCRIPTION
I had to base this change on https://github.com/ahungry/org-jira/pull/213, because our jira demands using accountId.
I add using type-id for issuetype, because for some reasons in jira we have three issuetype named Task with different id.
I had problem for update issue to jira because random type was received from list of all issue types. 