### PR TITLE
Update org-jira-log to avoid double substitution of messages

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -364,7 +364,7 @@ See `org-default-priority' for more info."
 
 (defvar org-jira-verbosity 'debug)
 
-(defun org-jira-log (s) (when (eq 'debug org-jira-verbosity) (message (format "%s" s))))
+(defun org-jira-log (s) (when (eq 'debug org-jira-verbosity) (message "%s" s)))
 
 (defmacro ensure-on-issue (&rest body)
   "Make sure we are on an issue heading, before executing BODY."


### PR DESCRIPTION
When org-jira-log is called with a string that has a % sequence in it,
the subsequent call to 'message would try to do substitution, and then
complain that not enough arguments were provided.  Because 'message
already incorporates 'format functionality, just remove the redundant
call to 'format.

The error was    (error "Not enough arguments for format string")

To reproduce

(org-jira-log "message with %s in it")

when org-jira-verbosity was set to 'debug