### PR TITLE
handle lists within work log comments so that they don't mess up org file rendering

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -805,7 +805,7 @@ This format is typically generated from org-jira-worklogs-to-org-clocks call."
   (org-end-of-line)
   (insert "\n")
   (insert (format "  :id: %s\n" (cadddr clock-entry)))
-  (when (caddr clock-entry) (insert (format "  %s\n" (org-jira-decode (caddr clock-entry))))) ;; No comment is nil, so don't print it
+  (when (caddr clock-entry) (insert (replace-regexp-in-string "^\\*" "-" (format "  %s\n" (org-jira-decode (caddr clock-entry)))))) ;; No comment is nil, so don't print it
   )
 
 (defun org-jira-logbook-reset (issue-id filename &optional clocks)


### PR DESCRIPTION
This is a fix for #243 , replacing asterisks with dashes after having the string formatted should take care of the problem. In my case it does solve the issue and the resulting org files from org-jira-get-issues are formatted correctly.