### PR TITLE
replace use of deprecated 'cl map with mapcar

### DIFF
--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -147,7 +147,7 @@
     (org-jira-sdk-issue
      :assignee (path '(fields assignee displayName))
      :components (mapconcat (lambda (c) (org-jira-sdk-path c '(name))) (path '(fields components)) ", ")
-     :labels (mapconcat (lambda (c) (format "%s" c)) (map 'list #'identity (path '(fields labels))) ", ")
+     :labels (mapconcat (lambda (c) (format "%s" c)) (mapcar #'identity (path '(fields labels))) ", ")
      :created (path '(fields created))     ; confirm
      :description (or (path '(fields description)) "")
      :duedate (path '(fields duedate))         ; confirm


### PR DESCRIPTION
I'm getting  a `(void-function map)` error when running org-jira as-written. This change, or adding `(require 'cl)` fixes it for me after I re-evaluate the buffer. I suspect this is a version issue on `cl-lib`? I'm on emacs 28.0.50, fwiw. 