### PR TITLE
prefix typep usage with cl

### DIFF
--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -213,9 +213,9 @@
 (defun org-jira-sdk-create-comment-from-data (d) (org-jira-sdk-create-from-data :comment d))
 (defun org-jira-sdk-create-comments-from-data-list (ds) (mapcar #'org-jira-sdk-create-comment-from-data ds))
 
-(defun org-jira-sdk-isa-record? (i) (typep i 'org-jira-sdk-record))
-(defun org-jira-sdk-isa-issue? (i) (typep i 'org-jira-sdk-issue))
-(defun org-jira-sdk-isa-comment? (i) (typep i 'org-jira-sdk-comment))
+(defun org-jira-sdk-isa-record? (i) (cl-typep i 'org-jira-sdk-record))
+(defun org-jira-sdk-isa-issue? (i) (cl-typep i 'org-jira-sdk-issue))
+(defun org-jira-sdk-isa-comment? (i) (cl-typep i 'org-jira-sdk-comment))
 
 ;; Board
 (defun org-jira-sdk-create-board-from-data (d) (org-jira-sdk-create-from-data :board d))


### PR DESCRIPTION
Closes #255 

I really don't understand how this has worked before, but I'm not exactly an expert on elisp. Seems as though it's just missing the `cl-` prefix, no?

I briefly searched across all of my elisp packages for instances of `typep` and can't seem to find any that aren't prefixed as they are here. More importantly, making this changes and evaluating the buffer results in a working `org-jira` for me again!