### PR TITLE
feat(auth): includes alt. representations of port in lookup

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -259,7 +259,9 @@ After a successful login, store the authentication token in
                                                        (url-host (url-generic-parse-url jiralib-url))
                                                      jiralib-host)
                                              ;; secrets.el wouldn’t accept a number.
-                                             :port (number-to-string (url-port (url-generic-parse-url jiralib-url)))
+                                             :port (list (number-to-string (url-port (url-generic-parse-url jiralib-url)))
+							 (url-port (url-generic-parse-url jiralib-url))
+							 (url-type (url-generic-parse-url jiralib-url)))
                                              :require '(:user :secret)
                                              :create t)))
            user secret)


### PR DESCRIPTION
Make the auth-source-search lookup a little more robust by including
other valid representations for valid values for port in the
`auth-source-search` lookup.

I noticed this because `org-jira` ignores my authinfo credential when it contains `:port https`.

ref: https://www.gnu.org/software/emacs/manual/html_mono/auth.html#Help-for-users