### PR TITLE
Small fixes for comments

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -1201,7 +1201,7 @@ ISSUES is a list of `org-jira-sdk-issue' records."
   "Update a comment for the current issue."
   (interactive)
   (let* ((issue-id (org-jira-get-from-org 'issue 'key)) ; Really the key
-         (filename (org-jira-get-from-org 'issue 'filename))
+         (filename (org-jira-filename))
          (comment-id (org-jira-get-from-org 'comment 'id))
          (comment (replace-regexp-in-string "^  " "" (org-jira-get-comment-body comment-id))))
     (lexical-let ((issue-id issue-id)
@@ -1230,7 +1230,7 @@ ISSUES is a list of `org-jira-sdk-issue' records."
   "For ISSUE-ID in FILENAME, add a new COMMENT string to the issue region."
   (interactive
    (let* ((issue-id (org-jira-get-from-org 'issue 'id))
-          (filename (org-jira-get-from-org 'issue 'filename))
+          (filename (org-jira-filename))
           (comment (read-string (format  "Comment (%s): " issue-id))))
      (list issue-id filename comment)))
   (lexical-let ((issue-id issue-id)
@@ -2275,7 +2275,7 @@ it is a symbol, it will be converted to string."
 
 (defun org-jira-filename ()
   "Get the ID entry for the current heading."
-  (org-entry-get (point) "filename"))
+  (org-jira-get-from-org 'issue 'filename))
 
 ;;;###autoload
 (defun org-jira-browse-issue ()

--- a/org-jira.el
+++ b/org-jira.el
@@ -1201,7 +1201,7 @@ ISSUES is a list of `org-jira-sdk-issue' records."
   "Update a comment for the current issue."
   (interactive)
   (let* ((issue-id (org-jira-get-from-org 'issue 'key)) ; Really the key
-         (filename (org-jira-filename))
+         (filename (org-jira-get-from-org 'issue 'filename))
          (comment-id (org-jira-get-from-org 'comment 'id))
          (comment (replace-regexp-in-string "^  " "" (org-jira-get-comment-body comment-id))))
     (lexical-let ((issue-id issue-id)

--- a/org-jira.el
+++ b/org-jira.el
@@ -1229,8 +1229,8 @@ ISSUES is a list of `org-jira-sdk-issue' records."
 (defun org-jira-add-comment (issue-id filename comment)
   "For ISSUE-ID in FILENAME, add a new COMMENT string to the issue region."
   (interactive
-   (let* ((issue-id (org-jira-id))
-          (filename (org-jira-filename))
+   (let* ((issue-id (org-jira-get-from-org 'issue 'id))
+          (filename (org-jira-get-from-org 'issue 'filename))
           (comment (read-string (format  "Comment (%s): " issue-id))))
      (list issue-id filename comment)))
   (lexical-let ((issue-id issue-id)


### PR DESCRIPTION
I would first say, thank you for maintaining the repo. :) 
I use this package daily for work and I noticed that almost every time I updated a comment it would give an error of issue not found and then open a new .org buffer.
It turned out that it couldn't figure out the right filename because the cursor wasn't in the highest heading level of the issue. And therefore couldn't find the property filename.

This is what I tried to fix with this so now it updates the comment without the error.

The same was for the add comment function. Mainly it couldn't find the id or filename unless you were in the highest heading of the issue.