### PR TITLE
Fix :type on jiralib-update-issue-fields-exclude-list

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -233,7 +233,12 @@ Example: (list '('t \"descriptive-predicate-label\" (lambda (x) x)))"
 (defcustom jiralib-update-issue-fields-exclude-list nil
   "A list of symbols to check for exclusion on updates based on matching key.
 Key names should be one of components, description, assignee, reporter, summary, issuetype."
-  :type 'list
+  :type '(set (const :tag "Exclude components" components)
+              (const :tag "Exclude description" description)
+              (const :tag "Exclude assignee" assignee)
+              (const :tag "Exclude reporter" reporter)
+              (const :tag "Exclude summary" summary)
+              (const :tat "Exclude issue type" issuetype))
   :group 'org-jira)
 
 (defun jiralib-load-wsdl ()


### PR DESCRIPTION
`jiralib-update-issue-fields-exclude-list`'s `:type` attribute in `defcustom` is currently malformed. A `list` typed custom variable must be of the form `(list e1 e2 e3 ... eN)` and have exactly `N` entries with the respective `e...` types.

Since `jiralib-update-issue-fields-exclude-list` should contain only a subset of `'(components description assignee reporter summary issuetype)` (or the whole set), I believe that a `set` of `const` is more appropriate. This also enables users to use `customize-variable` with the widget interface.