### PR TITLE
Get issues by sprint and adds sprint to properties

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -426,7 +426,6 @@ request.el, so if at all possible, it should be avoided."
                                                               "/rest/api/2/search"
                                                               :type "POST"
                                                               :data (json-encode `((jql . ,(first params))
-										   (fields . ("*all"))
                                                                                    (maxResults . ,(second params)))))))
                                         nil))
       ('getPriorities (jiralib--rest-call-it

--- a/jiralib.el
+++ b/jiralib.el
@@ -416,6 +416,11 @@ request.el, so if at all possible, it should be avoided."
 				   (format "rest/agile/1.0/board/%d/issue" (first params))
 				   'issues
 				   (cdr params)))
+      ('getSprintsFromBoard  (apply 'jiralib--agile-call-it
+				   (format "rest/agile/1.0/board/%d/sprint" (first params))
+				   'issues
+				   (cdr params)))
+      
       ('getIssuesFromJqlSearch  (append (cdr ( assoc 'issues (jiralib--rest-call-it
                                                               "/rest/api/2/search"
                                                               :type "POST"
@@ -1174,6 +1179,12 @@ Auxiliary Notes:
   "Return list of jira issues in the specified jira board"
   (apply 'jiralib-call "getIssuesFromBoard"
 	 (cl-getf params :callback) board-id params))
+
+(defun jiralib-get-board-sprints (board-id &rest params)
+  "Return list of jira sprints in the specified jira board"
+  (apply 'jiralib-call "getSprintsFromBoard"
+	 (cl-getf params :callback) board-id params))
+
 
 (defun jiralib--agile-not-last-entry (num-entries total start-at limit)
   "Return true if need to retrieve next page from agile api"

--- a/jiralib.el
+++ b/jiralib.el
@@ -319,7 +319,7 @@ This produces a noticeable slowdown and is not recommended by
 request.el, so if at all possible, it should be avoided."
   ;; @TODO :auth: Probably pass this all the way down, but I think
   ;; it may be OK at the moment to just set the variable each time.
-  (print params)
+  
   (setq jiralib-complete-callback
         ;; Don't run with async if we don't have a login token yet.
         (if jiralib-token callback nil))

--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -151,7 +151,7 @@
      :labels (mapconcat (lambda (c) (format "%s" c)) (mapcar #'identity (path '(fields labels))) ", ")
      :created (path '(fields created))     ; confirm
      :description (or (path '(fields description)) "")
-     :duedate (path '(fields duedate))         ; confirm
+     :duedate (or (path '(fields sprint endDate)) (path '(fields duedate)))         ; confirm
      :filename (path '(fields project key))
      :headline (path '(fields summary)) ; Duplicate of summary, maybe different.
      :id (path '(key))

--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -106,6 +106,7 @@
    (proj-key :type string :initarg :proj-key)
    (reporter :type (or null string) :initarg :reporter)
    (resolution :type (or null string) :initarg :resolution)
+   (sprint :type (or null string) :initarg :sprint)
    (start-date :type (or null string) :initarg :start-date)
    (status :type string :initarg :status)
    (summary :type string :initarg :summary)
@@ -160,6 +161,7 @@
      :proj-key (path '(fields project key))
      :reporter (path '(fields reporter displayName)) ; reporter could be an object of its own slot values
      :resolution (path '(fields resolution name))  ; confirm
+     :sprint (path '(fields sprint name))
      :start-date (path '(fields start-date))  ; confirm
      :status (org-jira-decode (path '(fields status name)))
      :summary (path '(fields summary))

--- a/org-jira.el
+++ b/org-jira.el
@@ -1686,6 +1686,7 @@ purpose of wiping an old subtree."
 
 (defvar org-jira-project-read-history nil)
 (defvar org-jira-boards-read-history nil)
+(defvar org-jira-sprints-read-history nil)
 (defvar org-jira-components-read-history nil)
 (defvar org-jira-priority-read-history nil)
 (defvar org-jira-type-read-history nil)
@@ -1711,6 +1712,17 @@ purpose of wiping an old subtree."
                            'org-jira-boards-read-history
                            (car org-jira-boards-read-history))))
     (assoc board-name boards-alist)))
+
+(defun org-jira-read-sprint (board)
+  "Read sprint name. Returns cons pair (name . integer-id)"
+  (let* ((sprints-alist
+	  (jiralib-make-assoc-list (append (alist-get 'values (jiralib-get-board-sprints board)) nil) 'name 'id))
+	  (sprint-name
+	   (completing-read "Sprints: " sprints-alist
+			    nil t nil
+			    'org-jira-sprints-read-history
+			    (car org-jira-sprints-read-history))))
+       (assoc sprint-name sprints-alist)))
 
 (defun org-jira-read-component (project)
   "Read the components options for PROJECT such as EX."
@@ -2394,6 +2406,18 @@ See `org-jira-get-issues-from-filter'."
                               :limit (org-jira-get-board-limit board-id)
                               :query-params (org-jira--make-jql-queryparams board-id))))
 
+;;;###autoload
+(defun org-jira-get-issues-by-sprint ()
+  "Get list of ISSUES from sprint."
+  (interactive)
+  (let* ((board (org-jira-read-board))
+	 (board-id (cdr board))
+	 (sprint (org-jira-read-sprint board-id))
+	 (sprint-id (cdr sprint)))
+    (jiralib-get-sprint-issues sprint-id
+			       :callback org-jira-get-issue-list-callback
+			       :limit (org-jira-get-board-limit board-id)
+			       :query-params (org-jira--make-jql-queryparams board-id))))
 
 (defun org-jira-get-board-limit (id)
   "Get limit for number of retrieved issues for a board

--- a/org-jira.el
+++ b/org-jira.el
@@ -2395,16 +2395,6 @@ See `org-jira-get-issues-from-filter'."
                               :callback org-jira-get-issue-list-callback
                               :limit (org-jira-get-board-limit board-id)
                               :query-params (org-jira--make-jql-queryparams board-id))))
-;;;###autoload
-(defun org-jira-get-sprints-by-board ()
-  "Get list of SPRINTS from agile board."
-  (interactive)
-  (let* ((board (org-jira-read-board))
-         (board-id (cdr board)))
-    (jiralib-get-board-sprints board-id
-                              :callback org-jira-get-sprint-list-callback
-                              :limit (org-jira-get-board-limit board-id)
-                              :query-params (org-jira--make-jql-queryparams board-id))))
 
 ;;;###autoload
 (defun org-jira-get-issues-by-sprint ()


### PR DESCRIPTION
Adds the following
- `org-jira-get-issues-by-sprint` which gets all tickets for a board by the sprint name
- `sprint` to properties
- sets due date to sprint end date if available and falls back to `dueDate` if not


