### PR TITLE
Fix #283. Jira API V2 is expecting a 'name' property

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -942,10 +942,10 @@ Return nil if the field is not found"
         return (cdr (assoc 'displayName user))))
 
 (defun jiralib-get-user-account-id (project full-name)
-    "Return the account-id (accountId) of the user with FULL-NAME (displayName) in PROJECT."
+    "Return the name of the user with FULL-NAME (displayName) in PROJECT."
   (cl-loop for user in (jiralib-get-users project)
         when (rassoc full-name user)
-        return (cdr (assoc 'accountId user))))
+        return (cdr (assoc 'name user))))
 
 (defun jiralib-get-filter (filter-id)
   "Return a filter given its FILTER-ID."

--- a/jiralib.el
+++ b/jiralib.el
@@ -942,6 +942,12 @@ Return nil if the field is not found"
         return (cdr (assoc 'displayName user))))
 
 (defun jiralib-get-user-account-id (project full-name)
+    "Return the account-id (accountId) of the user with FULL-NAME (displayName) in PROJECT."
+  (cl-loop for user in (jiralib-get-users project)
+        when (rassoc full-name user)
+        return (cdr (assoc 'accountId user))))
+
+(defun jiralib-get-user-name (project full-name)
     "Return the name of the user with FULL-NAME (displayName) in PROJECT."
   (cl-loop for user in (jiralib-get-users project)
         when (rassoc full-name user)

--- a/org-jira.el
+++ b/org-jira.el
@@ -2212,8 +2212,8 @@ otherwise it should return:
                    (cons 'priority (org-jira-get-id-name-alist org-issue-priority
                                                        (jiralib-get-priorities)))
                    (cons 'description org-issue-description)
-                   (cons 'assignee (list (cons 'id (jiralib-get-user-account-id project org-issue-assignee))))
-                   (cons 'reporter (list (cons 'id (jiralib-get-user-account-id project org-issue-reporter))))
+                   (cons 'assignee (list (cons 'name (jiralib-get-user-account-id project org-issue-assignee))))
+                   (cons 'reporter (list (cons 'name (jiralib-get-user-account-id project org-issue-reporter))))
                    (cons 'summary (org-jira-strip-priority-tags (org-jira-get-issue-val-from-org 'summary)))
                    (cons 'issuetype `((id . ,org-issue-type-id)
       (name . ,org-issue-type))))))

--- a/org-jira.el
+++ b/org-jira.el
@@ -1629,7 +1629,7 @@ purpose of wiping an old subtree."
                           (cdr (rassoc user jira-users)))))
           (when (null reporter)
             (error "No reporter found, this should probably never happen."))
-          (org-jira-update-issue-details issue-id filename :reporter (jiralib-get-user-account-id project reporter)))
+          (org-jira-update-issue-details issue-id filename :reporter (jiralib-get-user-name project reporter)))
       (error "Not on an issue"))))
 
 ;;;###autoload
@@ -1650,7 +1650,7 @@ purpose of wiping an old subtree."
                           (cdr (rassoc user jira-users)))))
           (when (null assignee)
             (error "No assignee found, use org-jira-unassign-issue to make the issue unassigned"))
-          (org-jira-update-issue-details issue-id filename :assignee (jiralib-get-user-account-id project assignee)))
+          (org-jira-update-issue-details issue-id filename :assignee (jiralib-get-user-name project assignee)))
       (error "Not on an issue"))))
 
 ;;;###autoload
@@ -2212,8 +2212,8 @@ otherwise it should return:
                    (cons 'priority (org-jira-get-id-name-alist org-issue-priority
                                                        (jiralib-get-priorities)))
                    (cons 'description org-issue-description)
-                   (cons 'assignee (list (cons 'name (jiralib-get-user-account-id project org-issue-assignee))))
-                   (cons 'reporter (list (cons 'name (jiralib-get-user-account-id project org-issue-reporter))))
+                   (cons 'assignee (list (cons 'name (jiralib-get-user-name project org-issue-assignee))))
+                   (cons 'reporter (list (cons 'name (jiralib-get-user-name project org-issue-reporter))))
                    (cons 'summary (org-jira-strip-priority-tags (org-jira-get-issue-val-from-org 'summary)))
                    (cons 'issuetype `((id . ,org-issue-type-id)
       (name . ,org-issue-type))))))


### PR DESCRIPTION
This fix is needed for Tickets updates with a recent Jira server.
(naive copy/paste from [pjgarcia](https://github.com/pjgarcia) comment in #283) 
I don't know if this fix is working also on legacy Jira servers.
Maybe it is needed to test Jira API version to implement a better fix.