### PR TITLE
Issue 320

### DIFF
--- a/org-jira.el
+++ b/org-jira.el
@@ -779,20 +779,10 @@ Example: \"2012-01-09T08:59:15.000Z\" becomes \"2012-01-09
   "Convert TIME-STAMP into org-clock format."
   (format-time-string "%Y-%m-%d %a %H:%M" time-stamp))
 
-(defun org-jira-date-strip-letter-t (date)
-  "Convert DATE into a time stamp and then into org-clock format.
-Expects a date in format such as: 2017-02-26T00:08:00.000-0500 and
-returns in format 2017-02-26 00:08:00-0500."
-  (replace-regexp-in-string
-   "\\.000\\([-+]\\)" "\\1"
-   (replace-regexp-in-string "^\\(.*?\\)T" "\\1 " date)))
-
 (defun org-jira-date-to-org-clock (date)
   "Convert DATE into a time stamp and then into org-clock format.
 Expects a date in format such as: 2017-02-26T00:08:00.000-0500."
-  (org-jira-time-stamp-to-org-clock
-   (date-to-time
-    (org-jira-date-strip-letter-t date))))
+  (org-jira-time-stamp-to-org-clock (date-to-time date)))
 
 (defun org-jira-worklogs-to-org-clocks (worklogs)
   "Get a list of WORKLOGS and convert to org-clocks."

--- a/t/org-jira-t.el
+++ b/t/org-jira-t.el
@@ -147,22 +147,22 @@
                 (issueId . "10402"))]))
   "A sample response, as served from the #'jiralib-get-worklogs call.")
 
-;; (ert-deftest org-jira-worklogs-to-org-clocks-test ()
-;;   (let ((result (org-jira-worklogs-to-org-clocks
-;;                  (cdr (assoc 'worklogs org-jira-worklog-fixture-response)))))
-;;     (should
-;;      (string= "2017-02-26 Sun 00:08"
-;;               (caar result)))
-;;     (should
-;;      (string= "2017-02-26 Sun 01:08"
-;;               (cadar result)))
-;;     (should
-;;      (string= "2017-03-16 Thu 22:25"
-;;               (caadr result)))
-;;     (should
-;;      (string= "2017-03-16 Thu 22:57"
-;;               (cadadr result)))
-;;     ))
+(ert-deftest org-jira-worklogs-to-org-clocks-test ()
+  (let ((result (org-jira-worklogs-to-org-clocks
+                 (cdr (assoc 'worklogs org-jira-worklog-fixture-response)))))
+    (should
+     (string= "2017-02-26 Sun 00:08"
+              (caar result)))
+    (should
+     (string= "2017-02-26 Sun 01:08"
+              (cadar result)))
+    (should
+     (string= "2017-03-16 Thu 22:25"
+              (caadr result)))
+    (should
+     (string= "2017-03-16 Thu 22:57"
+              (cadadr result)))
+    ))
 
 (ert-deftest org-jira-format-clock-test ()
     (should

--- a/t/org-jira-t.el
+++ b/t/org-jira-t.el
@@ -45,12 +45,6 @@
 
 (set-time-zone-rule t)
 
-(ert-deftest org-jira-date-strip-letter-t-test ()
-  (should
-   (string= "2017-01-01 00:00:00+0000"
-            (org-jira-date-strip-letter-t "2017-01-01T00:00:00.000+0000")))
-  )
-
 (ert-deftest org-jira-date-to-org-clock-test ()
   (should
    (string= "2017-01-01 Sun 00:00"


### PR DESCRIPTION
This fixes issue #320 by removing the function `org-jira-date-strip-letter-t`, since Emacs' `date-to-time` is able to understand ISO-8601 timestamps.