### PR TITLE
fix typos and spelling errors

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -43,7 +43,7 @@
 
 ;;; Commentary:
 
-;; This file provides a programatic interface to JIRA.  It provides access to
+;; This file provides a programmatic interface to JIRA.  It provides access to
 ;; JIRA from other programs, but no user level functionality.
 
 ;; Jira References:
@@ -1236,7 +1236,7 @@ performed asynchronously and JIRALIB-COMPLETE-CALLBACK will be
 called when all data are retrieved.
 
 If JIRALIB-COMPLETE-CALLBACK is nil, then the call will be
-performed syncronously and this function will return the
+performed synchronously and this function will return the
 retrieved data.
 
 API - path to called API that must start with /rest/agile/1.0.

--- a/org-jira.el
+++ b/org-jira.el
@@ -2218,7 +2218,7 @@ otherwise it should return:
       ;; update, why not?  This is better to fire first, because it
       ;; doesn't auto-refresh any areas, while the end of the main
       ;; update does a callback that reloads the worklog entries (so,
-      ;; we hope that wont occur until after this successfully syncs
+      ;; we hope that won't occur until after this successfully syncs
       ;; up).  Only do this sync if the user defcustom defines it as such.
       (when org-jira-worklog-sync-p
         (org-jira-update-worklogs-from-org-clocks))
@@ -2541,7 +2541,7 @@ boards -  list of `org-jira-sdk-board' records."
 
 ;;;###autoload
 (defun org-jira-get-boards ()
-  "Get list of boards and their properies."
+  "Get list of boards and their properties."
   (interactive)
   (let* ((datalist (jiralib-get-boards))
          (boards (org-jira-sdk-create-boards-from-data-list datalist)))

--- a/t/batch-runner/dash.el
+++ b/t/batch-runner/dash.el
@@ -346,7 +346,7 @@ See also: `-remove', `-map-last'"
 (defalias '--reject-last '--remove-last)
 
 (defun -remove-item (item list)
-  "Remove all occurences of ITEM from LIST.
+  "Remove all occurrences of ITEM from LIST.
 
 Comparison is done with `equal'."
   (declare (pure t) (side-effect-free t))
@@ -446,7 +446,7 @@ See also: `-replace-at'"
   (--map-when (equal it old) new list))
 
 (defun -replace-first (old new list)
-  "Replace the first occurence of OLD with NEW in LIST.
+  "Replace the first occurrence of OLD with NEW in LIST.
 
 Elements are compared using `equal'.
 
@@ -455,7 +455,7 @@ See also: `-map-first'"
   (--map-first (equal old it) new list))
 
 (defun -replace-last (old new list)
-  "Replace the last occurence of OLD with NEW in LIST.
+  "Replace the last occurrence of OLD with NEW in LIST.
 
 Elements are compared using `equal'.
 
@@ -1229,7 +1229,7 @@ release of Dash. If you rely on this behavior, use -zip-pair instead."
         (setq lists (mapcar 'cdr lists)))
       (setq results (nreverse results))
       (if (= (length lists) 2)
-          ;; to support backward compatability, return
+          ;; to support backward compatibility, return
           ;; a cons cell if two lists were provided
           (--map (cons (car it) (cadr it)) results)
         results))))


### PR DESCRIPTION
Fixing some minor typos and spelling errors which should not affect functionality but improve the overall quality of documentation.