### PR TITLE
Custom field support

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -238,7 +238,6 @@ Example: (list '('t \"descriptive-predicate-label\" (lambda (x) x)))"
   :type '(repeat (list boolean string function))
   :group 'org-jira)
 
-
 (defcustom jiralib-update-issue-fields-exclude-list nil
   "A list of symbols to check for exclusion on updates based on matching key.
 Key names should be one of components, description, assignee, reporter, summary, issuetype."
@@ -357,6 +356,7 @@ request.el, so if at all possible, it should be avoided."
     (cl-case (intern method)
       ('getStatuses (jiralib--rest-call-it "/rest/api/2/status"))
       ('getIssueTypes (jiralib--rest-call-it "/rest/api/2/issuetype"))
+      ('getIssueFields (jiralib--rest-call-it "/rest/api/2/field"))
       ('getSubTaskIssueTypes (jiralib--rest-call-it "/rest/api/2/issuetype"))
       ('getIssueTypesByProject
        (let ((response (jiralib--rest-call-it (format "/rest/api/2/project/%s" (first params)))))
@@ -1041,6 +1041,19 @@ CALLBACK will be invoked if passed in upon endpoint completion."
                    (timeSpentSeconds . ,time-spent-seconds)
                    (comment . ,comment))))
     (jiralib-call "updateWorklog" callback issue-id worklog-id worklog)))
+
+(defvar jiralib-issue-fields-cache nil
+  "Mapping of jiralib issue field keys to symbols.")
+
+(defun jiralib-get-issue-fields ()
+  "Return an assoc list mapping an issue field id to its details.
+
+This function will only ask JIRA for the list of fields once, then
+will cache it."
+  (unless jiralib-issue-fields-cache
+    (setq jiralib-issue-fields-cache
+          (jiralib-make-assoc-list (jiralib-call "getIssueFields" nil) 'id 'name)))
+  jiralib-issue-fields-cache)
 
 (defvar jiralib-components-cache nil "An alist of project components.")
 

--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -144,30 +144,35 @@
     (funcall hydrate-fn proj-key id callback)))
 
 (cl-defmethod org-jira-sdk-from-data ((rec org-jira-sdk-issue))
-  (cl-flet ((path (keys) (org-jira-sdk-path (oref rec data) keys)))
+  (cl-flet ((path (keys) (org-jira-sdk-path (oref rec data) keys))
+            (field (keys)
+                   (let* ((org-name (car keys))
+                          (jira-field-id (org-jira--org->api-field-id org-name))
+                         (path (cdr keys)))
+                     (result (org-jira-sdk-path (oref rec data) (cons 'fields (cons jira-field-id path)))))))
     (org-jira-sdk-issue
-     :assignee (path '(fields assignee displayName))
-     :components (mapconcat (lambda (c) (org-jira-sdk-path c '(name))) (path '(fields components)) ", ")
-     :labels (mapconcat (lambda (c) (format "%s" c)) (mapcar #'identity (path '(fields labels))) ", ")
-     :created (path '(fields created))     ; confirm
-     :description (or (path '(fields description)) "")
-     :duedate (or (path '(fields sprint endDate)) (path '(fields duedate)))         ; confirm
-     :filename (path '(fields project key))
-     :headline (path '(fields summary)) ; Duplicate of summary, maybe different.
+     :assignee (field '(assignee displayName))
+     :components (mapconcat (lambda (c) (org-jira-sdk-path c '(name))) (field '(components)) ", ")
+     :labels (mapconcat (lambda (c) (format "%s" c)) (mapcar #'identity (field '(labels))) ", ")
+     :created (field '(created))     ; confirm
+     :description (or (field '(description)) "")
+     :duedate (or (field '(sprint endDate)) (field '(duedate)))         ; confirm
+     :filename (field '(project key))
+     :headline (field '(summary)) ; Duplicate of summary, maybe different.
      :id (path '(key))
      :issue-id (path '(key))
      :issue-id-int (path '(id))
-     :priority (path '(fields priority name))
-     :proj-key (path '(fields project key))
-     :reporter (path '(fields reporter displayName)) ; reporter could be an object of its own slot values
-     :resolution (path '(fields resolution name))  ; confirm
-     :sprint (path '(fields sprint name))
-     :start-date (path '(fields start-date))  ; confirm
-     :status (org-jira-decode (path '(fields status name)))
-     :summary (path '(fields summary))
-     :type (path '(fields issuetype name))
-     :type-id (path '(fields issuetype id))
-     :updated (path '(fields updated))  ; confirm
+     :priority (field '(priority name))
+     :proj-key (field '(project key))
+     :reporter (field '(reporter displayName)) ; reporter could be an object of its own slot values
+     :resolution (field '(resolution name))  ; confirm
+     :sprint (field '(sprint name))
+     :start-date (field '(start-date))  ; confirm
+     :status (org-jira-decode (field '(status name)))
+     :summary (field '(summary))
+     :type (field '(issuetype name))
+     :type-id (field '(issuetype id))
+     :updated (field '(updated))  ; confirm
      ;; TODO: Remove this
      ;; :data (oref rec data)
      )))

--- a/org-jira-sdk.el
+++ b/org-jira-sdk.el
@@ -113,6 +113,7 @@
    (type :type string :initarg :type)
    (type-id :type string :initarg :type-id)
    (updated :type string :initarg :updated)
+   (custom-fields :type list :initarg :custom-fields)
    (data :initarg :data :documentation "The remote Jira data object (alist).")
    (hydrate-fn :initform #'jiralib-get-issue :initarg :hydrate-fn))
   "An issue on the end.  ID of the form EX-1, or a numeric such as 10000.")
@@ -149,7 +150,7 @@
                    (let* ((org-name (car keys))
                           (jira-field-id (org-jira--org->api-field-id org-name))
                          (path (cdr keys)))
-                     (result (org-jira-sdk-path (oref rec data) (cons 'fields (cons jira-field-id path)))))))
+                     (org-jira-sdk-path (oref rec data) (cons 'fields (cons jira-field-id path))))))
     (org-jira-sdk-issue
      :assignee (field '(assignee displayName))
      :components (mapconcat (lambda (c) (org-jira-sdk-path c '(name))) (field '(components)) ", ")
@@ -173,6 +174,9 @@
      :type (field '(issuetype name))
      :type-id (field '(issuetype id))
      :updated (field '(updated))  ; confirm
+     :custom-fields (cl-remove-if-not
+                     (lambda (f) (assoc (car f) org-jira-issue-custom-fields))
+                     (path '(fields)))
      ;; TODO: Remove this
      ;; :data (oref rec data)
      )))


### PR DESCRIPTION
Adds support for custom fields.

- Main behavior is controlled via `org-jira-issue-custom-fields`. Can set field type, display name and location (placed under a headline or property).
- By default, the field name is the readable name provided by the Jira API, sanitized for org property use. It can be overridden by the above alist.
- The built-in `org-jira` issue slots like `description` and `assignee` can now be overridden by custom fields using `org-jira-issue-field-overrides-alist`. This is in case the organization uses a custom field for the description/etc. of the issue instead of the default. Internally the field ID is converted to and from the slot name recognized by `org-jira` when interacting with the Jira API.