### PR TITLE
Constructing REST call headers with cons

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -505,7 +505,7 @@ passing ARGS to REQUEST."
                               (concat (replace-regexp-in-string "/*$" "/" jiralib-url)
                                       (replace-regexp-in-string "^/*" "" api)))
                   :sync (not jiralib-complete-callback)
-                  :headers `(,jiralib-token ("Content-Type" . "application/json"))
+                  :headers (cons '("Content-Type" . "application/json") jiralib-token)
                   :parser 'jiralib--json-read
                   :complete jiralib-complete-callback
                   ;; Ensure we have useful errors


### PR DESCRIPTION
My enterprise Jira instance requires several additional SSO-related headers to be provided with each request.
To do that I just created own function that replaces the `jiralib-login` and sets `jiralib-token` another way, but I can't put the headers into their place with current code since additional level of parentheses breaks the `requests` list parser.

This changes allows providing additional headers and shouldn't affect anything else.