### PR TITLE
Ensure issue creation honors ignored fields

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -603,7 +603,6 @@ emacs-lisp"
 
     (apply 'vector (nreverse remote-field-values))))
 
-
 ;;;; Wrappers around JIRA methods
 
 (defun jiralib--rest-api-for-issue-key (key)


### PR DESCRIPTION
Previously ignored fields were only being honored on issue update, but not issue creation. This updates the create issue struct so that it filters out fields that the user wants removed, via jiralib-update-issue-fields-exclude-list.

FWIW I'm extremely new to elisp, so happy to take feedback/pointers if any of my choices here aren't as clean as they could be. 

I've tested this and it is working as intended