### PR TITLE
Add support for username-based assignment for older JIRA instances

### DIFF
--- a/jiralib.el
+++ b/jiralib.el
@@ -362,6 +362,7 @@ request.el, so if at all possible, it should be avoided."
        (let ((response (jiralib--rest-call-it (format "/rest/api/2/project/%s" (first params)))))
          (cl-coerce (cdr (assoc 'issueTypes response)) 'list)))
       ('getUser (jiralib--rest-call-it "/rest/api/2/user" :params `((accountId . ,(first params)))))
+      ('getUserByUsername (jiralib--rest-call-it "/rest/api/2/user" :params `((username . ,(first params)))))
       ('getVersions (jiralib--rest-call-it (format "/rest/api/2/project/%s/versions" (first params))))
 
       ;; Worklog calls

--- a/org-jira.el
+++ b/org-jira.el
@@ -2223,6 +2223,7 @@ otherwise it should return:
            (org-issue-type (org-jira-get-issue-val-from-org 'type))
            (org-issue-type-id (org-jira-get-issue-val-from-org 'type-id))
            (org-issue-assignee (cl-getf rest :assignee (org-jira-get-issue-val-from-org 'assignee)))
+           (org-issue-assignee-username (cl-getf rest :assignee-username (org-jira-get-issue-val-from-org 'assignee-username)))
            (org-issue-reporter (cl-getf rest :reporter (org-jira-get-issue-val-from-org 'reporter)))
            (project (replace-regexp-in-string "-[0-9]+" "" issue-id))
            (project-components (jiralib-get-components project)))
@@ -2247,7 +2248,10 @@ otherwise it should return:
                    (cons 'priority (org-jira-get-id-name-alist org-issue-priority
                                                        (jiralib-get-priorities)))
                    (cons 'description org-issue-description)
-                   (cons 'assignee (list (cons 'id (jiralib-get-user-account-id project org-issue-assignee))))
+                   ;; If org-issue-assignee-username is set, grab the username instead of the assignee value
+                   (if (stringp org-issue-assignee-username)
+                          (cons 'assignee (list (cons 'name org-issue-assignee-username)))
+                          (cons 'assignee (list (cons 'id (jiralib-get-user-account-id project org-issue-assignee)))))
                    (cons 'summary (org-jira-strip-priority-tags (org-jira-get-issue-val-from-org 'summary)))
                    (cons 'issuetype `((id . ,org-issue-type-id)
       (name . ,org-issue-type))))))


### PR DESCRIPTION
## Summary

This PR adds support for direct username assignment when working with older JIRA instances that don't support the newer accountId-based user lookup.

## Changes

### jiralib.el
- Added `getUserByUsername` method that queries users by username instead of accountId
- Uses the standard `/rest/api/2/user` endpoint with `username` parameter

### org-jira.el  
- Added support for `assignee-username` property in issue updates
- Conditional logic that prioritizes username-based assignment when `assignee-username` is provided
- Maintains full backward compatibility with existing accountId-based assignment

## Why This Change?

Older JIRA instances (pre-GDPR compliance updates) required username-based user assignment rather than the newer accountId approach. This change enables org-jira to work with both:

1. **Modern JIRA instances**: Continue using accountId-based assignment (existing behavior)
2. **Older JIRA instances**: Use direct username assignment via the new `assignee-username` property

## Backward Compatibility

✅ **Fully backward compatible** - existing configurations continue to work unchanged

## Testing

- [x] Tested with existing accountId-based assignment (no regression)
- [x] Tested with new username-based assignment for older JIRA instances
- [x] Verified fallback behavior works correctly

This addresses compatibility issues that prevented org-jira from working with older JIRA deployments.